### PR TITLE
DM-52228: Add simple Repertoire server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ WORKDIR /app
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the application.
-CMD ["uvicorn", "repertoire.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "--factory", "repertoire.main:create_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 requires-python = ">=3.13"
 dependencies = [
     "jinja2>=3",
-    "pydantic>2",
+    "pydantic>=2.10",
+    "pydantic-settings>=2.6",
     "pyyaml>=6",
 ]
 dynamic = ["version"]

--- a/client/src/rubin/repertoire/__init__.py
+++ b/client/src/rubin/repertoire/__init__.py
@@ -1,7 +1,7 @@
 """Client, models, and URL construction for Repertoire."""
 
 from ._builder import RepertoireBuilder
-from ._config import DatasetConfig, RepertoireConfig
+from ._config import DatasetConfig, RepertoireSettings
 from ._models import Dataset, Discovery, ServiceUrls
 
 __all__ = [
@@ -9,7 +9,7 @@ __all__ = [
     "DatasetConfig",
     "Discovery",
     "RepertoireBuilder",
-    "RepertoireConfig",
+    "RepertoireSettings",
     "Rule",
     "ServiceUrls",
 ]

--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -8,7 +8,7 @@ from pydantic import HttpUrl
 from ._config import (
     DataServiceRule,
     InternalServiceRule,
-    RepertoireConfig,
+    RepertoireSettings,
     Rule,
     UiServiceRule,
 )
@@ -31,7 +31,7 @@ class RepertoireBuilder:
         Repertoire configuration.
     """
 
-    def __init__(self, config: RepertoireConfig) -> None:
+    def __init__(self, config: RepertoireSettings) -> None:
         self._config = config
 
         self._base_context = {

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -8,10 +8,11 @@ from typing import Annotated, Literal, Self
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 from pydantic.alias_generators import to_camel
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 __all__ = [
     "DatasetConfig",
-    "RepertoireConfig",
+    "RepertoireSettings",
     "Rule",
 ]
 
@@ -92,15 +93,18 @@ type Rule = Annotated[
 ]
 
 
-class RepertoireConfig(BaseModel):
+class RepertoireSettings(BaseSettings):
     """Base configuration from which Repertoire constructs URLs.
 
     This roughly represents the merged Phalanx configuration of the Repertoire
     service for a given environment, and is also used during the Phalanx build
-    process to build static service discovery information.
+    process to build static service discovery information. It is defined with
+    ``pydantic_settings.BaseSettings`` as the base class instead of
+    ``pydantic.BaseModel`` so that the main settings class of the Repertoire
+    server can inherit from it.
     """
 
-    model_config = ConfigDict(
+    model_config = SettingsConfigDict(
         alias_generator=to_camel, extra="forbid", validate_by_name=True
     )
 
@@ -110,7 +114,7 @@ class RepertoireConfig(BaseModel):
             title="Phalanx services",
             description="Names of deployed Phalanx services",
         ),
-    ]
+    ] = set()
 
     base_url: Annotated[
         HttpUrl,

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,7 @@
 """nox configuration for Repertoire."""
 
+from __future__ import annotations
+
 import nox
 from nox_uv import session
 

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 from pydantic import Field, SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from safir.logging import LogLevel, Profile
+from safir.logging import (
+    LogLevel,
+    Profile,
+    configure_logging,
+    configure_uvicorn_logging,
+)
 
-__all__ = ["Config", "config"]
+from rubin.repertoire import RepertoireSettings
+
+__all__ = ["Config"]
 
 
-class Config(BaseSettings):
+class Config(RepertoireSettings):
     """Configuration for Repertoire."""
-
-    model_config = SettingsConfigDict(
-        env_prefix="REPERTOIRE_", case_sensitive=False
-    )
 
     log_level: LogLevel = Field(
         LogLevel.INFO, title="Log level of the application's logger"
@@ -34,6 +36,10 @@ class Config(BaseSettings):
         description="If set, alerts will be posted to this Slack webhook",
     )
 
-
-config = Config()
-"""Configuration for Repertoire."""
+    def configure_logging(self) -> None:
+        """Configure logging based on the Repertoire configuration."""
+        configure_logging(
+            profile=self.profile, log_level=self.log_level, name="repertoire"
+        )
+        if self.profile == Profile.production:
+            configure_uvicorn_logging(self.log_level)

--- a/src/repertoire/constants.py
+++ b/src/repertoire/constants.py
@@ -1,0 +1,8 @@
+"""Constants for Repertoire."""
+
+from __future__ import annotations
+
+__all__ = ["CONFIG_PATH"]
+
+CONFIG_PATH = "/etc/repertoire/config.yaml"
+"""Default configuration path."""

--- a/src/repertoire/dependencies/config.py
+++ b/src/repertoire/dependencies/config.py
@@ -1,0 +1,62 @@
+"""Config dependency for FastAPI."""
+
+import os
+from pathlib import Path
+
+from ..config import Config
+from ..constants import CONFIG_PATH
+
+__all__ = ["ConfigDependency", "config_dependency"]
+
+
+class ConfigDependency:
+    """Provides the configuration as a dependency.
+
+    We want a production deployment to default to one configuration path, but
+    allow that path to be overridden by the test suite and, if the path
+    changes, to reload the configuration (which allows sharing the same set of
+    global singletons across multiple tests). Do this by loading the config
+    dynamically when it's first requested and reloading it whenever the
+    configuration path is changed.
+    """
+
+    def __init__(self) -> None:
+        config_path = os.getenv("REPERTOIRE_CONFIG_PATH", CONFIG_PATH)
+        self._config_path = Path(config_path)
+        self._config: Config | None = None
+
+    async def __call__(self) -> Config:
+        """Load the configuration if necessary and return it."""
+        return self.config()
+
+    @property
+    def config_path(self) -> Path:
+        """Path to the configuration file."""
+        return self._config_path
+
+    def config(self) -> Config:
+        """Load the configuration if necessary and return it.
+
+        This is equivalent to using the dependency as a callable except that
+        it's not async and can therefore be used from non-async functions.
+        """
+        if not self._config:
+            self._config = Config.from_file(self._config_path)
+            self._config.configure_logging()
+        return self._config
+
+    def set_config_path(self, path: Path) -> None:
+        """Change the configuration path and reload the config.
+
+        Parameters
+        ----------
+        path
+            The new configuration path.
+        """
+        self._config_path = path
+        self._config = Config.from_file(path)
+        self._config.configure_logging()
+
+
+config_dependency = ConfigDependency()
+"""The dependency that will return the current configuration."""

--- a/src/repertoire/dependencies/discovery.py
+++ b/src/repertoire/dependencies/discovery.py
@@ -1,0 +1,36 @@
+"""Build and cache the service discovery information."""
+
+from typing import Annotated
+
+from fastapi import Depends
+
+from rubin.repertoire import Discovery, RepertoireBuilder
+
+from ..config import Config
+from .config import config_dependency
+
+__all__ = ["DiscoveryDependency", "discovery_dependency"]
+
+
+class DiscoveryDependency:
+    """Build and cache the service discovery information.
+
+    Currently, service discovery information is only calculated once during
+    startup. In the future, this may become more complex by using dynamic
+    registration.
+    """
+
+    def __init__(self) -> None:
+        self._discovery: Discovery | None = None
+
+    async def __call__(
+        self, config: Annotated[Config, Depends(config_dependency)]
+    ) -> Discovery:
+        """Generate discovery information if needed and return it."""
+        if not self._discovery:
+            self._discovery = RepertoireBuilder(config).build()
+        return self._discovery
+
+
+discovery_dependency = DiscoveryDependency()
+"""The dependency that will return the current service discovery data."""

--- a/src/repertoire/handlers/external.py
+++ b/src/repertoire/handlers/external.py
@@ -3,12 +3,14 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from safir.dependencies.logger import logger_dependency
 from safir.metadata import get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
-from structlog.stdlib import BoundLogger
 
-from ..config import config
+from rubin.repertoire import Discovery
+
+from ..config import Config
+from ..dependencies.config import config_dependency
+from ..dependencies.discovery import discovery_dependency
 from ..models import Index
 
 __all__ = ["external_router"]
@@ -23,9 +25,20 @@ external_router = APIRouter(route_class=SlackRouteErrorHandler)
     summary="Application metadata",
 )
 async def get_index(
-    logger: Annotated[BoundLogger, Depends(logger_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
 ) -> Index:
     metadata = get_metadata(
         package_name="repertoire", application_name=config.name
     )
     return Index(metadata=metadata)
+
+
+@external_router.get(
+    "/discovery",
+    response_model_exclude_none=True,
+    summary="Discovery information",
+)
+async def get_discovery(
+    discovery: Annotated[Discovery, Depends(discovery_dependency)],
+) -> Discovery:
+    return discovery

--- a/src/repertoire/handlers/internal.py
+++ b/src/repertoire/handlers/internal.py
@@ -8,11 +8,14 @@ These handlers should be used for monitoring, health checks, internal status,
 or other information that should not be visible outside the Kubernetes cluster.
 """
 
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
 from safir.metadata import Metadata, get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from ..config import config
+from ..config import Config
+from ..dependencies.config import config_dependency
 
 __all__ = ["internal_router"]
 
@@ -31,8 +34,9 @@ internal_router = APIRouter(route_class=SlackRouteErrorHandler)
     response_model_exclude_none=True,
     summary="Application metadata",
 )
-async def get_index() -> Metadata:
+async def get_index(
+    config: Annotated[Config, Depends(config_dependency)],
+) -> Metadata:
     return get_metadata(
-        package_name="repertoire",
-        application_name=config.name,
+        package_name="repertoire", application_name=config.name
     )

--- a/tests/client/builder_test.py
+++ b/tests/client/builder_test.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from rubin.repertoire import RepertoireBuilder, RepertoireConfig
+from rubin.repertoire import RepertoireBuilder, RepertoireSettings
 
 from ..support.data import data_path, read_test_json
 
 
 def test_builder() -> None:
     config_path = data_path("config/phalanx.yaml")
-    config = RepertoireConfig.from_file(config_path)
+    config = RepertoireSettings.from_file(config_path)
     output = RepertoireBuilder(config).build()
     output_json = output.model_dump(mode="json", exclude_none=True)
     assert output_json == read_test_json("output/phalanx")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,10 @@ from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from repertoire import main
+from repertoire.dependencies.config import config_dependency
+from repertoire.main import create_app
+
+from .support.data import data_path
 
 
 @pytest_asyncio.fixture
@@ -19,8 +22,10 @@ async def app() -> AsyncGenerator[FastAPI]:
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
-    async with LifespanManager(main.app):
-        yield main.app
+    config_dependency.set_config_path(data_path("config/minimal.yaml"))
+    app = create_app()
+    async with LifespanManager(app):
+        yield app
 
 
 @pytest_asyncio.fixture

--- a/tests/data/config/minimal.yaml
+++ b/tests/data/config/minimal.yaml
@@ -1,0 +1,1 @@
+baseUrl: "https://data.example.com"

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -1,4 +1,4 @@
-# A typical merged Phalanx configuration for, say, data.lsst.cloud.
+# A typical merged Phalanx configuration for, say, data.example.com.
 
 availableServices:
   - "argocd"
@@ -27,10 +27,10 @@ availableServices:
   - "vault-secrets-operator"
   - "vo-cutouts"
   - "wobbly"
-baseUrl: "https://data.lsst.cloud/"
+baseUrl: "https://data.example.com/"
 butlerConfigs:
-  dp02: "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
-  dp1: "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+  dp02: "https://data.example.com/api/butler/repo/dp02/butler.yaml"
+  dp1: "https://data.example.com/api/butler/repo/dp1/butler.yaml"
 datasets:
   - name: "dp02"
   - name: "dp03"

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -2,14 +2,14 @@
   "datasets": [
     {
       "name": "dp02",
-      "butler_config": "https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml"
+      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml"
     },
     {
       "name": "dp03"
     },
     {
       "name": "dp1",
-      "butler_config": "https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml"
+      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
     }
   ],
   "services": [
@@ -43,30 +43,30 @@
   "urls": {
     "data": {
       "cutout": {
-        "dp02": "https://data.lsst.cloud/api/cutout",
-        "dp03": "https://data.lsst.cloud/api/cutout",
-        "dp1": "https://data.lsst.cloud/api/cutout"
+        "dp02": "https://data.example.com/api/cutout",
+        "dp03": "https://data.example.com/api/cutout",
+        "dp1": "https://data.example.com/api/cutout"
       },
       "sia": {
-        "dp02": "https://data.lsst.cloud/api/sia/dp02",
-        "dp1": "https://data.lsst.cloud/api/sia/dp1"
+        "dp02": "https://data.example.com/api/sia/dp02",
+        "dp1": "https://data.example.com/api/sia/dp1"
       },
       "tap": {
-        "dp02": "https://data.lsst.cloud/api/tap",
-        "dp03": "https://data.lsst.cloud/api/ssotap",
-        "dp1": "https://data.lsst.cloud/api/tap"
+        "dp02": "https://data.example.com/api/tap",
+        "dp03": "https://data.example.com/api/ssotap",
+        "dp1": "https://data.example.com/api/tap"
       }
     },
     "internal": {
-      "gafaelfawr": "https://data.lsst.cloud/auth/api/v1",
-      "mobu": "https://data.lsst.cloud/mobu",
-      "noteburst": "https://data.lsst.cloud/noteburst/v1",
-      "semaphore": "https://data.lsst.cloud/semaphore",
-      "wobbly": "https://data.lsst.cloud/wobbly"
+      "gafaelfawr": "https://data.example.com/auth/api/v1",
+      "mobu": "https://data.example.com/mobu",
+      "noteburst": "https://data.example.com/noteburst/v1",
+      "semaphore": "https://data.example.com/semaphore",
+      "wobbly": "https://data.example.com/wobbly"
     },
     "ui": {
-      "nublado": "https://nb.data.lsst.cloud/nb",
-      "portal": "https://data.lsst.cloud/portal/app/"
+      "nublado": "https://nb.data.example.com/nb",
+      "portal": "https://data.example.com/portal/app/"
     }
   }
 }

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -5,18 +5,27 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from repertoire.config import config
+from repertoire.dependencies.config import config_dependency
+
+from ..support.data import data_path, read_test_json
 
 
 @pytest.mark.asyncio
 async def test_get_index(client: AsyncClient) -> None:
-    """Test ``GET /repertoire/``."""
-    response = await client.get("/repertoire/")
-    assert response.status_code == 200
-    data = response.json()
+    r = await client.get("/repertoire/")
+    assert r.status_code == 200
+    data = r.json()
     metadata = data["metadata"]
-    assert metadata["name"] == config.name
+    assert metadata["name"] == config_dependency.config().name
     assert isinstance(metadata["version"], str)
     assert isinstance(metadata["description"], str)
     assert isinstance(metadata["repository_url"], str)
     assert isinstance(metadata["documentation_url"], str)
+
+
+@pytest.mark.asyncio
+async def test_get_discovery(client: AsyncClient) -> None:
+    config_dependency.set_config_path(data_path("config/phalanx.yaml"))
+    r = await client.get("/repertoire/discovery")
+    assert r.status_code == 200, f"error body: {r.text}"
+    assert r.json() == read_test_json("output/phalanx")

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from repertoire.config import config
+from repertoire.dependencies.config import config_dependency
 
 
 @pytest.mark.asyncio
@@ -14,7 +14,7 @@ async def test_get_index(client: AsyncClient) -> None:
     response = await client.get("/")
     assert response.status_code == 200
     data = response.json()
-    assert data["name"] == config.name
+    assert data["name"] == config_dependency.config().name
     assert isinstance(data["version"], str)
     assert isinstance(data["description"], str)
     assert isinstance(data["repository_url"], str)

--- a/uv.lock
+++ b/uv.lock
@@ -1778,13 +1778,15 @@ source = { editable = "client" }
 dependencies = [
     { name = "jinja2" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3" },
-    { name = "pydantic", specifier = ">2" },
+    { name = "pydantic", specifier = ">=2.10" },
+    { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "pyyaml", specifier = ">=6" },
 ]
 


### PR DESCRIPTION
Implement the first version of the Repertoire server, which loads its configuration dynamically from a YAML file, generates discovery information from it, and returns that at `/repertoire/discovery`.