### PR TITLE
DM-52228: Rename some model and config settings

### DIFF
--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -34,10 +34,7 @@ class RepertoireBuilder:
     def __init__(self, config: RepertoireSettings) -> None:
         self._config = config
 
-        self._base_context = {
-            "base_url": str(config.base_url).rstrip("/"),
-            "base_hostname": config.base_url.host,
-        }
+        self._base_context = {"base_hostname": config.base_hostname}
         self._datasets = {d.name for d in config.datasets}
 
     def build(self) -> Discovery:
@@ -49,8 +46,8 @@ class RepertoireBuilder:
             Service discovery information.
         """
         return Discovery(
+            applications=sorted(self._config.applications),
             datasets=self._build_datasets(),
-            services=sorted(self._config.available_services),
             urls=self._build_urls(),
         )
 
@@ -66,13 +63,13 @@ class RepertoireBuilder:
     def _build_urls(self) -> ServiceUrls:
         """Construct the service URLs for an environment."""
         urls = ServiceUrls()
-        for service in sorted(self._config.available_services):
-            if service in self._config.use_subdomains:
-                rules = self._config.subdomain_rules.get(service, [])
+        for application in sorted(self._config.applications):
+            if application in self._config.use_subdomains:
+                rules = self._config.subdomain_rules.get(application, [])
             else:
-                rules = self._config.rules.get(service, [])
+                rules = self._config.rules.get(application, [])
             for rule in rules:
-                self._build_url_from_rule(service, rule, urls)
+                self._build_url_from_rule(application, rule, urls)
         return urls
 
     def _build_url_from_rule(
@@ -83,7 +80,7 @@ class RepertoireBuilder:
         Parameters
         ----------
         name
-            Name of the service.
+            Name of the application.
         rule
             Generation rule for the URL.
         urls

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -108,19 +108,19 @@ class RepertoireSettings(BaseSettings):
         alias_generator=to_camel, extra="forbid", validate_by_name=True
     )
 
-    available_services: Annotated[
+    applications: Annotated[
         set[str],
         Field(
-            title="Phalanx services",
-            description="Names of deployed Phalanx services",
+            title="Phalanx applications",
+            description="Names of deployed Phalanx applications",
         ),
     ] = set()
 
-    base_url: Annotated[
-        HttpUrl,
+    base_hostname: Annotated[
+        str,
         Field(
-            title="Base URL",
-            description="Base URL for the Phalanx environment",
+            title="Base hostname",
+            description="Base hostname for the Phalanx environment",
         ),
     ]
 

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -80,22 +80,22 @@ class ServiceUrls(BaseModel):
 class Discovery(BaseModel):
     """Service discovery information."""
 
+    applications: Annotated[
+        list[str],
+        Field(
+            title="Phalanx applications",
+            description=(
+                "Names of all Phalanx applications enabled in the local"
+                " environment"
+            ),
+        ),
+    ] = []
+
     datasets: Annotated[
         list[Dataset],
         Field(
             title="Datasets",
             description="All datasets available in the local environment",
-        ),
-    ] = []
-
-    services: Annotated[
-        list[str],
-        Field(
-            title="Phalanx services",
-            description=(
-                "Names of all Phalanx services deployed in the local"
-                " environment"
-            ),
         ),
     ] = []
 

--- a/tests/data/config/minimal.yaml
+++ b/tests/data/config/minimal.yaml
@@ -1,1 +1,1 @@
-baseUrl: "https://data.example.com"
+baseHostname: "data.example.com"

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -1,6 +1,6 @@
 # A typical merged Phalanx configuration for, say, data.example.com.
 
-availableServices:
+applications:
   - "argocd"
   - "butler"
   - "cert-manager"
@@ -27,7 +27,7 @@ availableServices:
   - "vault-secrets-operator"
   - "vo-cutouts"
   - "wobbly"
-baseUrl: "https://data.example.com/"
+baseHostname: "data.example.com"
 butlerConfigs:
   dp02: "https://data.example.com/api/butler/repo/dp02/butler.yaml"
   dp1: "https://data.example.com/api/butler/repo/dp1/butler.yaml"
@@ -36,58 +36,62 @@ datasets:
   - name: "dp03"
   - name: "dp1"
 rules:
+  argocd:
+    - type: "ui"
+      name: "argocd"
+      template: "https://{{base_hostname}}/argo-cd"
   gafaelfawr:
     - type: "internal"
       name: "gafaelfawr"
-      template: "{{base_url}}/auth/api/v1"
+      template: "https://{{base_hostname}}/auth/api/v1"
   mobu:
     - type: "internal"
       name: "mobu"
-      template: "{{base_url}}/mobu"
+      template: "https://{{base_hostname}}/mobu"
   noteburst:
     - type: "internal"
       name: "noteburst"
-      template: "{{base_url}}/noteburst/v1"
+      template: "https://{{base_hostname}}/noteburst/v1"
   nublado:
     - type: "ui"
       name: "nublado"
-      template: "{{base_url}}/nb"
+      template: "https://{{base_hostname}}/nb"
   portal:
     - type: "ui"
       name: "portal"
-      template: "{{base_url}}/portal/app/"
+      template: "https://{{base_hostname}}/portal/app/"
   semaphore:
     - type: "internal"
       name: "semaphore"
-      template: "{{base_url}}/semaphore"
+      template: "https://{{base_hostname}}/semaphore"
   sia:
     - type: "data"
       name: "sia"
       datasets:
         - "dp02"
         - "dp1"
-      template: "{{base_url}}/api/sia/{{dataset}}"
+      template: "https://{{base_hostname}}/api/sia/{{dataset}}"
   ssotap:
     - type: "data"
       name: "tap"
       datasets:
         - "dp03"
-      template: "{{base_url}}/api/ssotap"
+      template: "https://{{base_hostname}}/api/ssotap"
   tap:
     - type: "data"
       name: "tap"
       datasets:
         - "dp02"
         - "dp1"
-      template: "{{base_url}}/api/tap"
+      template: "https://{{base_hostname}}/api/tap"
   vo-cutouts:
     - type: "data"
       name: "cutout"
-      template: "{{base_url}}/api/cutout"
+      template: "https://{{base_hostname}}/api/cutout"
   wobbly:
     - type: "internal"
       name: "wobbly"
-      template: "{{base_url}}/wobbly"
+      template: "https://{{base_hostname}}/wobbly"
 subdomainRules:
   nublado:
     - type: "ui"

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -1,18 +1,5 @@
 {
-  "datasets": [
-    {
-      "name": "dp02",
-      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml"
-    },
-    {
-      "name": "dp03"
-    },
-    {
-      "name": "dp1",
-      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
-    }
-  ],
-  "services": [
+  "applications": [
     "argocd",
     "butler",
     "cert-manager",
@@ -40,6 +27,19 @@
     "vo-cutouts",
     "wobbly"
   ],
+  "datasets": [
+    {
+      "name": "dp02",
+      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml"
+    },
+    {
+      "name": "dp03"
+    },
+    {
+      "name": "dp1",
+      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
+    }
+  ],
   "urls": {
     "data": {
       "cutout": {
@@ -65,6 +65,7 @@
       "wobbly": "https://data.example.com/wobbly"
     },
     "ui": {
+      "argocd": "https://data.example.com/argo-cd",
       "nublado": "https://nb.data.example.com/nb",
       "portal": "https://data.example.com/portal/app/"
     }


### PR DESCRIPTION
Rename `availableServices` and `services` to `applications` to match the Phalanx terminology. Change `baseUrl` to `baseHostname` in the configuration since `baseUrl` is deprecated in Phalanx (by, ironically, service discovery).

Add Argo CD to the UI applications in the test data to match the expected initial Phalanx configuration.