### PR TITLE
DM-52228: Adjust configuration for Phalanx chart

### DIFF
--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field, SecretStr
+from pydantic import AliasChoices, Field, SecretStr
 from safir.logging import (
     LogLevel,
     Profile,
@@ -22,24 +22,35 @@ class Config(RepertoireSettings):
         LogLevel.INFO, title="Log level of the application's logger"
     )
 
+    log_profile: Profile = Field(
+        Profile.development, title="Application logging profile"
+    )
+
     name: str = Field("Repertoire", title="Name of application")
 
     path_prefix: str = Field("/repertoire", title="URL prefix for application")
 
-    profile: Profile = Field(
-        Profile.development, title="Application logging profile"
+    slack_alerts: bool = Field(
+        False,
+        title="Enable Slack alerts",
+        description="If true, slackWebhook must also be set",
     )
 
     slack_webhook: SecretStr | None = Field(
         None,
         title="Slack webhook for alerts",
         description="If set, alerts will be posted to this Slack webhook",
+        validation_alias=AliasChoices(
+            "REPERTOIRE_SLACK_WEBHOOK", "slackWebhook"
+        ),
     )
 
     def configure_logging(self) -> None:
         """Configure logging based on the Repertoire configuration."""
         configure_logging(
-            profile=self.profile, log_level=self.log_level, name="repertoire"
+            profile=self.log_profile,
+            log_level=self.log_level,
+            name="repertoire",
         )
-        if self.profile == Profile.production:
+        if self.log_profile == Profile.production:
             configure_uvicorn_logging(self.log_level)

--- a/src/repertoire/main.py
+++ b/src/repertoire/main.py
@@ -40,7 +40,7 @@ def create_app() -> FastAPI:
     app.add_middleware(XForwardedMiddleware)
 
     # Configure Slack alerts.
-    if config.slack_webhook:
+    if config.slack_alerts and config.slack_webhook:
         logger = structlog.get_logger("repertoire")
         SlackRouteErrorHandler.initialize(
             config.slack_webhook, "Repertoire", logger


### PR DESCRIPTION
Rename `profile` to `log_profile`, matching our Phalanx `values.yaml` convention (which is a bit more obvious). Add `slack_alerts`, since the chart uses that to trigger other configuration. Support setting the Slack webhook via an environment variable.