### PR TITLE
DM-52228: Add GitHub Actions for PyPI uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,3 +143,40 @@ jobs:
         with:
           image: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  test-packaging:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Test building and publishing rubin-repertoire
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
+        with:
+          upload: false
+          working-directory: "client"
+
+  pypi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [test, docs, test-packaging]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/safir
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Test building and publishing rubin-repertoire
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
+        with:
+          working-directory: "client"

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -87,3 +87,29 @@ jobs:
           notification_title: "Periodic documentation test for {repo} failed"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
+  pypi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [test, docs]
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # full history for setuptools_scm
+
+      - name: Test package build of rubin-repertoire
+        uses: lsst-sqre/build-and-publish-to-pypi@v3
+        with:
+          upload: false
+          working-directory: "client"
+
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic packaging test for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Add the GitHub Actions support for testing packaging and uploading to PyPI.