### PR TITLE
DM-52228: Add butler_repositories method to client

### DIFF
--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -220,6 +220,28 @@ class DiscoveryClient:
                 return str(candidate.butler_config)
         return None
 
+    async def butler_repositories(self) -> dict[str, str]:
+        """Return the Butler repository mapping for the local environment.
+
+        Returns
+        -------
+        dict of str
+            Mapping of dataset labels to Butler configuration URLs. This
+            result is suitable for use as the constructor argument to
+            ``lsst.daf.butler.LabeledButlerFactory``.
+
+        Raises
+        ------
+        RepertoireError
+            Raised on error fetching discovery information from Repertoire.
+        """
+        discovery = await self._get_data()
+        return {
+            d.name: str(d.butler_config)
+            for d in discovery.datasets
+            if d.butler_config is not None
+        }
+
     async def datasets(self) -> list[str]:
         """List datasets available in the local Phalanx environment.
 

--- a/tests/client/service_test.py
+++ b/tests/client/service_test.py
@@ -46,6 +46,17 @@ async def test_butler_config_for(discovery: DiscoveryClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_butler_repositories(discovery: DiscoveryClient) -> None:
+    output = read_test_json("output/phalanx")
+    expected = {
+        d["name"]: d["butler_config"]
+        for d in output["datasets"]
+        if d.get("butler_config") is not None
+    }
+    assert await discovery.butler_repositories() == expected
+
+
+@pytest.mark.asyncio
 async def test_url_for(discovery: DiscoveryClient) -> None:
     output = read_test_json("output/phalanx")
     urls = output["urls"]


### PR DESCRIPTION
Add a method to get the repository mapping needed as the constructor argument to `lsst.daf.butler.LabeledButlerFactory`.