### PR TITLE
DM-52228: Add initial documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
-docs/api/
+docs/_static/
+docs/user-guide/server-api
 
 # PyBuilder
 target/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: uv-lock
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.12.12
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/client/src/rubin/repertoire/__init__.py
+++ b/client/src/rubin/repertoire/__init__.py
@@ -1,27 +1,37 @@
 """Client, models, and URL construction for Repertoire."""
 
 from ._builder import RepertoireBuilder
-from ._client import (
-    DiscoveryClient,
+from ._client import DiscoveryClient
+from ._config import (
+    BaseRule,
+    DataServiceRule,
+    DatasetConfig,
+    InternalServiceRule,
+    RepertoireSettings,
+    UiServiceRule,
+)
+from ._exceptions import (
     RepertoireError,
     RepertoireUrlError,
     RepertoireValidationError,
     RepertoireWebError,
 )
-from ._config import DatasetConfig, RepertoireSettings
 from ._models import Dataset, Discovery, ServiceUrls
 
 __all__ = [
+    "BaseRule",
+    "DataServiceRule",
     "Dataset",
     "DatasetConfig",
     "Discovery",
     "DiscoveryClient",
+    "InternalServiceRule",
     "RepertoireBuilder",
     "RepertoireError",
     "RepertoireSettings",
     "RepertoireUrlError",
     "RepertoireValidationError",
     "RepertoireWebError",
-    "Rule",
     "ServiceUrls",
+    "UiServiceRule",
 ]

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -3,128 +3,18 @@
 from __future__ import annotations
 
 import os
-from typing import Self
 
-from httpx import AsyncClient, HTTPError, HTTPStatusError
+from httpx import AsyncClient, HTTPError
 from pydantic import ValidationError
 
+from ._exceptions import (
+    RepertoireUrlError,
+    RepertoireValidationError,
+    RepertoireWebError,
+)
 from ._models import Discovery
 
-__all__ = [
-    "DiscoveryClient",
-    "RepertoireError",
-    "RepertoireUrlError",
-    "RepertoireValidationError",
-    "RepertoireWebError",
-]
-
-
-class RepertoireError(Exception):
-    """Base class for Repertoire client exceptions."""
-
-
-class RepertoireUrlError(RepertoireError):
-    """Base URL for Repertoire was not set."""
-
-
-class RepertoireValidationError(RepertoireError):
-    """Discovery information does not pass schema validation."""
-
-
-class RepertoireWebError(RepertoireError):
-    """Exception arising from an HTTP request failure.
-
-    Parameters
-    ----------
-    message
-        Exception string value.
-    method
-        Method of request.
-    url
-        URL of the request.
-    status
-        Status code of failure, if any.
-    body
-        Body of failure message, if any.
-
-    Attributes
-    ----------
-    method
-        Method of failing request, if available.
-    url
-        URL of failing request, if available.
-    status
-        HTTP status of failing request, if available.
-    body
-        Body of error message from server, if available.
-    """
-
-    @classmethod
-    def from_exception(cls, exc: HTTPError) -> Self:
-        """Create an exception from an HTTPX_ exception.
-
-        Parameters
-        ----------
-        exc
-            Exception from HTTPX.
-
-        Returns
-        -------
-        RepertoireWebError
-            Newly-constructed exception.
-        """
-        if isinstance(exc, HTTPStatusError):
-            status = exc.response.status_code
-            method = exc.request.method
-            message = f"Status {status} from {method} {exc.request.url}"
-            return cls(
-                message,
-                method=exc.request.method,
-                url=str(exc.request.url),
-                status=status,
-                body=exc.response.text,
-            )
-        else:
-            exc_name = type(exc).__name__
-            message = f"{exc_name}: {exc!s}" if str(exc) else exc_name
-
-            # All httpx.HTTPError exceptions have a slot for the request,
-            # initialized to None and then sometimes added by child
-            # constructors or during exception processing. The request
-            # property is a property method that raises RuntimeError if
-            # request has not been set, so we can't just check for None. Hence
-            # this approach of attempting to use the request and falling back
-            # on reporting less data if that raised any exception.
-            try:
-                return cls(
-                    message,
-                    method=exc.request.method,
-                    url=str(exc.request.url),
-                )
-            except Exception:
-                return cls(message)
-
-    def __init__(
-        self,
-        message: str,
-        *,
-        method: str | None = None,
-        url: str | None = None,
-        status: int | None = None,
-        body: str | None = None,
-    ) -> None:
-        super().__init__(message)
-        self._message = message
-        self.method = method
-        self.url = url
-        self.status = status
-        self.body = body
-
-    def __str__(self) -> str:
-        result = self._message
-        if self.body:
-            result += f"\nBody:\n{self.body}\n"
-        return result
+__all__ = ["DiscoveryClient"]
 
 
 class DiscoveryClient:
@@ -133,7 +23,7 @@ class DiscoveryClient:
     Services that want to discover Phalanx services and datasets and that are
     not using the IVOA discovery protocols should use this client. Software
     running on a Science Pipelines stack container should instead use the
-    client provided by :py:mod:`lsst.rsp`.
+    client provided by ``lsst.rsp``.
 
     Discovery information is cached inside this client where appropriate.
     Callers should call the methods on this object each time discovery

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -187,7 +187,7 @@ class RepertoireSettings(BaseSettings):
 
         Returns
         -------
-        RepertoireConfig
+        RepertoireSettings
             The corresponding configuration.
         """
         with path.open("r") as f:

--- a/client/src/rubin/repertoire/_exceptions.py
+++ b/client/src/rubin/repertoire/_exceptions.py
@@ -1,0 +1,122 @@
+"""Exception classes for Repertoire."""
+
+from __future__ import annotations
+
+from typing import Self
+
+from httpx import HTTPError, HTTPStatusError
+
+__all__ = [
+    "RepertoireError",
+    "RepertoireUrlError",
+    "RepertoireValidationError",
+    "RepertoireWebError",
+]
+
+
+class RepertoireError(Exception):
+    """Base class for Repertoire client exceptions."""
+
+
+class RepertoireUrlError(RepertoireError):
+    """Base URL for Repertoire was not set."""
+
+
+class RepertoireValidationError(RepertoireError):
+    """Discovery information does not pass schema validation."""
+
+
+class RepertoireWebError(RepertoireError):
+    """Exception arising from an HTTP request failure.
+
+    Parameters
+    ----------
+    message
+        Exception string value.
+    method
+        Method of request.
+    url
+        URL of the request.
+    status
+        Status code of failure, if any.
+    body
+        Body of failure message, if any.
+
+    Attributes
+    ----------
+    method
+        Method of failing request, if available.
+    url
+        URL of failing request, if available.
+    status
+        HTTP status of failing request, if available.
+    body
+        Body of error message from server, if available.
+    """
+
+    @classmethod
+    def from_exception(cls, exc: HTTPError) -> Self:
+        """Create an exception from an HTTPX_ exception.
+
+        Parameters
+        ----------
+        exc
+            Exception from HTTPX.
+
+        Returns
+        -------
+        RepertoireWebError
+            Newly-constructed exception.
+        """
+        if isinstance(exc, HTTPStatusError):
+            status = exc.response.status_code
+            method = exc.request.method
+            message = f"Status {status} from {method} {exc.request.url}"
+            return cls(
+                message,
+                method=exc.request.method,
+                url=str(exc.request.url),
+                status=status,
+                body=exc.response.text,
+            )
+        else:
+            exc_name = type(exc).__name__
+            message = f"{exc_name}: {exc!s}" if str(exc) else exc_name
+
+            # All httpx.HTTPError exceptions have a slot for the request,
+            # initialized to None and then sometimes added by child
+            # constructors or during exception processing. The request
+            # property is a property method that raises RuntimeError if
+            # request has not been set, so we can't just check for None. Hence
+            # this approach of attempting to use the request and falling back
+            # on reporting less data if that raised any exception.
+            try:
+                return cls(
+                    message,
+                    method=exc.request.method,
+                    url=str(exc.request.url),
+                )
+            except Exception:
+                return cls(message)
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        method: str | None = None,
+        url: str | None = None,
+        status: int | None = None,
+        body: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self._message = message
+        self.method = method
+        self.url = url
+        self.status = status
+        self.body = body
+
+    def __str__(self) -> str:
+        result = self._message
+        if self.body:
+            result += f"\nBody:\n{self.body}\n"
+        return result

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,7 +1,12 @@
+.. _Butler: https://pipelines.lsst.io/modules/lsst.daf.butler/index.html
 .. _Click: https://click.palletsprojects.com/
+.. _HTTPX: https://www.python-httpx.org/
 .. _mypy: http://www.mypy-lang.org
+.. _nox: https://nox.thea.codes/en/stable/index.html
+.. _Phalanx: https://phalanx.lsst.io/
 .. _pre-commit: https://pre-commit.com
 .. _pytest: https://docs.pytest.org/en/latest/
 .. _scriv: https://scriv.readthedocs.io/en/stable/
 .. _semver: https://semver.org/
-.. _tox: https://tox.wiki/en/latest/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _uv: https://docs.astral.sh/uv/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,8 @@
-:og:description: Comprehensive API documentation for repertoire.
+:og:description: Comprehensive API documentation for rubin.repertoire.
 
-####################
-Python API reference
-####################
+###########################
+Python client API reference
+###########################
 
-.. automodapi:: repertoire
+.. automodapi:: rubin.repertoire
    :include-all-objects:

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,10 +1,10 @@
-:og:description: Learn how to contribute to the repertoire open source project.
+:og:description: Learn how to contribute to the Repertoire open source project.
 
 ############
 Contributing
 ############
 
-Learn how to contribute to the repertoire open source project.
+Learn how to contribute to the Repertoire open source project.
 
 .. toctree::
    :caption: Guides

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -2,14 +2,14 @@
 Release procedure
 #################
 
-This page gives an overview of how repertoire releases are made.
+This page gives an overview of how Repertoire releases are made.
 This information is only useful for maintainers.
 
-repertoire's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, `repertoire is released to PyPI`_ with that version.
+Repertoire's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
+When a semantic version tag is pushed to GitHub, the Repertoire client is `released to PyPI`_ with that version.
 Similarly, documentation is built and pushed for each version (see https://repertoire.lsst.io/v).
 
-.. _`repertoire is released to PyPI`: https://pypi.org/project/repertoire/
+.. _`released to PyPI`: https://pypi.org/project/rubin-repertoire/
 .. _`ci.yaml`: https://github.com/lsst-sqre/repertoire/blob/main/.github/workflows/ci.yaml
 
 .. _regular-release:
@@ -33,7 +33,7 @@ When it comes time to make the release, there should be a collection of change l
 Those fragments will make up the change log for the new release.
 
 Review those fragments to determine the version number of the next release.
-Safir follows semver_, so follow its rules to pick the next version:
+Repertoire follows semver_, so follow its rules (summarized below) to pick the next version:
 
 .. rst-class:: compact
 
@@ -41,9 +41,10 @@ Safir follows semver_, so follow its rules to pick the next version:
 - If there are any new features, increment the minor version number and set the patch version to 0.
 - Otherwise, increment the patch version number.
 
-Then, run ``scriv collect --version <version>`` specifying the version number you decided on.
+Then, run :command:`uv run scriv collect --version <version>`, specifying the version number you decided on.
 This will delete the fragment files and collect them into :file:`CHANGELOG.md` under an entry for the new release.
 Review that entry and edit it as needed (proofread, change the order to put more important things first, etc.).
+
 scriv will put blank lines between entries from different files.
 You may wish to remove those blank lines to ensure consistent formatting by various Markdown parsers.
 
@@ -54,27 +55,29 @@ Finally, create a PR from those changes and merge it before continuing with the 
 
 Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__ to create releases and their corresponding Git tags.
 
-1. Specify a tag from the appropriate branch (typically ``main``).
-   This tag's name is :pep:`440` and is usually formatted at ``X.Y.Z`` (without a ``v`` prefix).
+1. For the tag, enter the version number of the release in the :guilabel:`Find or create a new tag` box in the dropdown under :guilabel:`Select tag`.
+   The tag must follow the :pep:`440` specification since Repertoire uses setuptools_scm_ to set version metadata based on Git tags.
+   In particular, don't prefix the tag with ``v``.
 
-2. For the release name, repeat the version string.
+   .. _setuptools_scm: https://github.com/pypa/setuptools_scm
 
-3. Fill in the release notes, copied from the release notes.
-   You can use GitHub's change log feature to additionally generate a list of PRs included in the release.
+2. Ensure the branch target is set appropriately (normally ``main``).
 
-The tag **must** follow the :pep:`440` specification since repertoire uses setuptools_scm_ to set version metadata based on Git tags.
-In particular, **don't** prefix the tag with ``v``.
+3. For the release title, repeat the version string.
 
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm
+4. Click the :guilabel:`Generate release notes` button to include the GitHub-generated summary of pull requests in the release notes.
 
-The `ci.yaml`_ GitHub Actions workflow uploads the new release to PyPI and documentation to https://repertoire.lsst.io.
+5. In the release notes box above the generated notes, paste the contents of the :file:`CHANGELOG.md` entry for this release, without the initial heading specifying the version number and date.
+   Adjust the heading depth of the subsections to use ``##`` instead of ``###`` to match the pull request summary.
+
+The `ci.yaml`_ GitHub Actions workflow will upload the new release to PyPI, documentation to https://repertoire.lsst.io, and a Docker image to the GitHub Container Registry.
 
 .. _backport-release:
 
 Backport releases
 =================
 
-The regular release procedure works from the main line of development on the ``master`` Git branch.
+The regular release procedure works from the main line of development on the ``main`` Git branch.
 To create a release that patches an earlier major or minor version, you need to release from a **release branch.**
 
 Creating a release branch
@@ -86,7 +89,7 @@ If the release branch doesn't already exist, check out the latest patch for that
 .. code-block:: sh
 
    git checkout X.Y.Z
-   git checkout -b X.Y
+   git switch -c X.Y
    git push -u
 
 Developing on a release branch

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -1,16 +1,21 @@
 [project]
-title = "repertoire"
+title = "Repertoire"
 copyright = "2025 Association of Universities for Research in Astronomy, Inc. (AURA)"
+
+[project.openapi]
+openapi_path = "_static/openapi.json"
+doc_path = "user-guide/server-api"
+
+[project.openapi.generator]
+function = "repertoire.main:create_openapi"
+keyword_args = { add_back_link = true }
 
 [project.python]
 package = "repertoire"
 
 [sphinx]
 rst_epilog_file = "_rst_epilog.rst"
-disable_primary_sidebars = [
-    "index",
-    "changelog",
-]
+disable_primary_sidebars = ["index", "changelog"]
 
 [sphinx.intersphinx.projects]
 python = "https://docs.python.org/3/"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,19 +1,5 @@
-:og:description: Service discovery for the Rubin Science Platform
+:og:description: Service discovery for Phalanx
 :html_theme.sidebar_secondary.remove:
-
-##########
-repertoire
-##########
-
-Service discovery for the Rubin Science Platform
-
-Install repertoire from PyPI:
-
-.. code-block:: bash
-
-   pip install repertoire
-
-repertoire is developed on GitHub at https://github.com/lsst-sqre/repertoire.
 
 .. toctree::
    :hidden:
@@ -22,3 +8,35 @@ repertoire is developed on GitHub at https://github.com/lsst-sqre/repertoire.
    API <api>
    Change log <changelog>
    Contributing <dev/index>
+
+##########
+Repertoire
+##########
+
+Repertoire is a service and associated client library that provides service and data discovery for Phalanx_ environments, including the Rubin Science Platform.
+The service is deployed in each Phalanx environment that requires service discovery.
+The client is available from PyPI and intended for any service that needs to know the URLs of other Phalanx services or other information about what datasets and applications are deployed in the local Phalanx environment.
+
+For more detailed information about the design of Repertoire, see :dmtn:`250`.
+
+repertoire is developed on GitHub at https://github.com/lsst-sqre/repertoire.
+
+.. grid:: 3
+
+   .. grid-item-card:: User Guide
+      :link: user-guide/index
+      :link-type: doc
+
+      Learn how to query Repertoire for data and service discovery information.
+
+   .. grid-item-card:: API
+      :link: api
+      :link-type: doc
+
+      See the full API documentation for the Repertoire client.
+
+   .. grid-item-card:: Development
+      :link: dev/index
+      :link-type: doc
+
+      Learn how to contribute to the Repertoire codebase.

--- a/docs/user-guide/applications.rst
+++ b/docs/user-guide/applications.rst
@@ -1,0 +1,32 @@
+:og:description: Listing applications installed in the local environment.
+
+.. py:currentmodule:: rubin.repertoire
+
+####################
+Listing applications
+####################
+
+To get a list of all Phalanx applications enabled in the local environment, call `DiscoveryClient.applications`:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient()
+   applications = await discovery.applications()
+
+The result is a list of Phalanx application names.
+These are the same names used in the `Phalanx applications list <https://phalanx.lsst.io/applications/index.html>`__, without the description or category.
+
+Phalanx applications are not the same as service names.
+Many Phalanx applications do not register a service for service discovery, some register multiple services, and in some cases the service name is different from the application name.
+
+This method is relatively rarely used.
+It is primarily intended for services such as `mobu <https://mobu.lsst.io/>`__ that make decisions based on the Phalanx applications deployed in the environment.
+
+Next steps
+==========
+
+- Query for service URLs: :doc:`services`
+- Query for datasets: :doc:`datasets`

--- a/docs/user-guide/datasets.rst
+++ b/docs/user-guide/datasets.rst
@@ -1,0 +1,37 @@
+:og:description: Listing datasets available in the local environment.
+
+.. py:currentmodule:: rubin.repertoire
+
+################
+Listing datasets
+################
+
+To list all of the datasets available in the local environment, call `DiscoveryClient.datasets`.
+The result will be a list of the short dataset names.
+
+These names are the valid arguments for the dataset parameters to `DiscoveryClient.url_for_data_service` and `DiscoveryClient.butler_config_for` in that environment.
+
+For example:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient()
+   datasets = await discovery.datasets()
+   for dataset in datasets:
+       url = await discovery.url_for_data_service("cutout", dataset)
+       if url:
+           print(f"Cutout API for {dataset}: {url}")
+       else:
+           print(f"Cutouts for {dataset} not available")
+
+Currently, only the names of datasets are returned.
+More information about datasets will likely be available in future versions.
+
+Next steps
+==========
+
+- Query for service URLs: :doc:`services`
+- Query for Phalanx applications: :doc:`applications`

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -1,9 +1,27 @@
-:og:description: Learn how to use repertoire.
+:og:description: Learn how to use Repertoire.
 
 ##########
 User guide
 ##########
 
-.. .. toctree::
-..    :maxdepth: 2
-.. .. :titlesonly:
+Python consumers of data and service discovery information should use the Repertoire client, `rubin.repertoire`.
+This library is available from PyPI and can be declared as a dependency or installed with pip in the normal way:
+
+.. prompt:: bash
+
+   pip install rubin-repertoire
+
+Consumers in other languages, such as JavaScript, can use the Repertoire server API directly.
+
+.. toctree::
+   :caption: Python client
+
+   initialization
+   services
+   datasets
+   applications
+
+.. toctree::
+   :caption: Server
+
+   server-api

--- a/docs/user-guide/initialization.rst
+++ b/docs/user-guide/initialization.rst
@@ -1,0 +1,70 @@
+:og:description: Learn how to initialize the Repertoire client.
+
+.. py:currentmodule:: rubin.repertoire
+
+############################
+Creating a Repertoire client
+############################
+
+Most users of Repertoire can create a client with a simple call to the constructor of `DiscoveryClient`:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient()
+
+However, some Phalanx configuration for the client is required first.
+
+Phalanx configuration for Repertoire
+====================================
+
+The URL for the local Repertoire service will be obtained from the ``REPERTOIRE_BASE_URL`` environment variable.
+This, in turn, should be injected into the client's environment via Phalanx, using the Phalanx ``global.repertoireUrl`` Helm variable, which is created by Argo CD.
+
+If this environment variable is not set, the `DiscoveryClient` constructor will raise `RepertoireUrlError`.
+
+Older applications whose Helm charts were created before Repertoire will not be configured to inject either this Helm setting or this environment variable.
+See the Phalanx documentation on `adding Repertoire support <https://phalanx.lsst.io/developers/add-repertoire.html>`__ if you are adding Repertoire support to an older application.
+
+Override the base URL
+=====================
+
+If the client knows the base URL for the Repertoire REST API via some other mechanism, it can override the base URL with a constructor paramter to `DiscoveryClient`:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient(base_url="https://example.com/repertoire")
+
+In this case, the environment variable is ignored and may be unset.
+
+Provide an HTTPX client
+=======================
+
+By default, Repertoire creates a new HTTPX_ client.
+This is slightly wasteful if the application already has an HTTPX client, since it will create a new connection pool.
+
+To use an existing HTTPX ``AsyncClient`` for making requests to Repertoire, pass it in as the first argument to the `DiscoveryClient` constructor:
+
+.. code-block:: python
+
+   from httpx import AsyncClient
+   from rubin.repertoire import DiscoveryClient
+
+
+   client = AsyncClient()
+   discovery = DiscoveryClient(client)
+
+This is also the pattern to use if the Repertoire client needs custom HTTPX configuration for whatever reason, such as custom timeouts or special headers.
+That configuration can be added to the HTTPX client before passing it into the `DiscoveryClient` constructor.
+
+Next steps
+==========
+
+- Query for service URLs: :doc:`services`
+- Query for datasets: :doc:`datasets`
+- Query for Phalanx applications: :doc:`applications`

--- a/docs/user-guide/server-api.rst
+++ b/docs/user-guide/server-api.rst
@@ -1,0 +1,5 @@
+#####################
+Repertoire server API
+#####################
+
+This is a stub page for the API.

--- a/docs/user-guide/services.rst
+++ b/docs/user-guide/services.rst
@@ -1,0 +1,56 @@
+:og:description: Requesting service URLs from Repertoire.
+
+.. py:currentmodule:: rubin.repertoire
+
+################
+Finding services
+################
+
+Repertoire's discovery endpoint provides the URLs of other services running in the same Phalanx environment.
+
+Service types
+=============
+
+Services are divided into three classes:
+
+#. Data services: REST APIs, one base URL per dataset name (although for some services all the URLs may be the same), and intended for use either by users directly or by other services.
+#. UI services: browser UIs, one entry-point URL per Phalanx environment, intended for use by users or administrators.
+#. Internal services: REST APIs, one base URL per Phalanx environment, used primarily (but not necessarily exclusively) by other services and not by users directly.
+
+Service APIs
+============
+
+`DiscoveryClient` provides the following methods to look up services:
+
+`DiscoveryClient.url_for_data_service`
+    Takes the name of the service and the name of the dataset and returns the corresponding base URL for that service's REST API, or `None` if that service is not running in the local Phalanx environment or if it doesn't provide that dataset.
+    See :doc:`datasets` for information on how to find the dataset names available in the local environment.
+
+`DiscoveryClient.url_for_internal_service`
+    Takes the name of the service and returns the base URL for that service's REST API, or `None` if that service is not running in the local Phalanx environment.
+
+`DiscoveryClient.url_for_ui_service`
+    Takes the name of the service and returns the entry-point URL for the browser-based user interface, or `None` if that service is not running in the local Phalanx environment.
+
+URLs are returned as strings.
+These APIs do not require authentication.
+
+Butler configuration
+====================
+
+Configuring a client of the Butler_ service is a special case.
+The base URL of the Butler service REST API is not available through the above service APIs.
+The Butler client instead requires a URL to a configuration file.
+
+Clients that need to instantiate a single Butler for a specific dataset should call `DiscoveryClient.butler_config_for` and pass in the name of a dataset.
+The return value will be a URL to the Butler configuration for that dataset, or `None` if no Butler for that dataset is available.
+This URL, in turn, can be used to the ``Butler`` constructor.
+
+Clients that need to handle all available datasets and create a Butler on the fly for each request should call `DiscoveryClient.butler_repositories` and pass the result into the constructor of ``LabeledButlerFactory``.
+The resulting factory can then be used to create Butler instances for labels as needed.
+
+Next steps
+==========
+
+- Query for datasets: :doc:`datasets`
+- Query for Phalanx applications: :doc:`applications`

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,26 @@ nox.options.default_venv_backend = "uv"
 nox.options.reuse_existing_virtualenvs = True
 
 
+@session(uv_groups=["dev", "docs"])
+def docs(session: nox.Session) -> None:
+    """Build the documentation."""
+    doctree_dir = (session.cache_dir / "doctrees").absolute()
+    with session.chdir("docs"):
+        session.run(
+            "sphinx-build",
+            "-W",
+            "--keep-going",
+            "-n",
+            "-T",
+            "-b",
+            "html",
+            "-d",
+            str(doctree_dir),
+            ".",
+            "./_build/html",
+        )
+
+
 @session(uv_only_groups=["lint"], uv_no_install_project=True)
 def lint(session: nox.Session) -> None:
     """Run pre-commit hooks."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "respx",
 ]
 docs = [
-    "documenteer[guide]>=2",
+    "documenteer[guide]>=2.3",
     "scriv[toml]>=1.5",
 ]
 lint = [

--- a/src/repertoire/main.py
+++ b/src/repertoire/main.py
@@ -1,9 +1,11 @@
 """The main application factory for the Repertoire service."""
 
+import json
 from importlib.metadata import metadata, version
 
 import structlog
 from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
 from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.slack.webhook import SlackRouteErrorHandler
 
@@ -14,38 +16,78 @@ from .handlers.internal import internal_router
 __all__ = ["create_app"]
 
 
-def create_app() -> FastAPI:
+def create_app(*, load_config: bool = True) -> FastAPI:
     """Create the FastAPI application.
 
     This is in a function rather than using a global variable (as is more
     typical for FastAPI) because the configuration is loaded from a YAML file
     and we want to provide a chance for the test suite to configure the
     location of that YAML file.
+
+    Parameters
+    ----------
+    load_config
+        If set to `False`, do not try to load the configuration. This is used
+        primarily for OpenAPI schema generation, where constructing the app is
+        required but the configuration won't matter.
     """
-    config = config_dependency.config()
+    path_prefix = "/repertoire"
+    if load_config:
+        config = config_dependency.config()
+        path_prefix = config.path_prefix
+
+        # Configure Slack alerts.
+        if config.slack_alerts and config.slack_webhook:
+            logger = structlog.get_logger("repertoire")
+            SlackRouteErrorHandler.initialize(
+                config.slack_webhook, "Repertoire", logger
+            )
+            logger.debug("Initialized Slack webhook")
+
+    # Create the application.
     app = FastAPI(
         title="Repertoire",
         description=metadata("repertoire")["Summary"],
         version=version("repertoire"),
-        openapi_url=f"{config.path_prefix}/openapi.json",
-        docs_url=f"{config.path_prefix}/docs",
-        redoc_url=f"{config.path_prefix}/redoc",
+        openapi_url=f"{path_prefix}/openapi.json",
+        docs_url=f"{path_prefix}/docs",
+        redoc_url=f"{path_prefix}/redoc",
     )
 
     # Attach the routers.
     app.include_router(internal_router)
-    app.include_router(external_router, prefix=f"{config.path_prefix}")
+    app.include_router(external_router, prefix=path_prefix)
 
     # Add middleware.
     app.add_middleware(XForwardedMiddleware)
 
-    # Configure Slack alerts.
-    if config.slack_alerts and config.slack_webhook:
-        logger = structlog.get_logger("repertoire")
-        SlackRouteErrorHandler.initialize(
-            config.slack_webhook, "Repertoire", logger
-        )
-        logger.debug("Initialized Slack webhook")
-
     # Return the constructed app.
     return app
+
+
+def create_openapi(*, add_back_link: bool = False) -> str:
+    """Generate the OpenAPI schema.
+
+    Parameters
+    ----------
+    add_back_link
+        Whether to add a back link to the parent page to the description.
+        This is useful when the schema will be rendered as part of the
+        documentation.
+
+    Returns
+    -------
+    str
+        OpenAPI schema as serialized JSON.
+    """
+    app = create_app(load_config=False)
+    description = app.description
+    if add_back_link:
+        description += "\n\n[Return to Repertoire documentation](index.html)."
+    schema = get_openapi(
+        title=app.title,
+        description=description,
+        version=app.version,
+        routes=app.routes,
+    )
+    return json.dumps(schema)

--- a/uv.lock
+++ b/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "dataclasses-avroschema"
-version = "0.65.12"
+version = "0.65.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "casefy" },
@@ -405,9 +405,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/ac/7e112be499c9076daccf674864a1e0e7129a0ab2386ced2264d69619ded1/dataclasses_avroschema-0.65.12.tar.gz", hash = "sha256:4a95e9cd02b627a4f33b0d19e71aec2fe7af6958d475830f31e1ad2de4ed4eea", size = 45316, upload-time = "2025-07-18T23:45:19.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/8f/258cf08e073b8181b9dd4c7ac8b07e2475bcfe36f7120a434ee80f712330/dataclasses_avroschema-0.65.13.tar.gz", hash = "sha256:6cbfe3a9e9227d51fb882e3d2281efe9e74d29861bd94bb863f24655cc9bc101", size = 45337, upload-time = "2025-09-04T20:30:17.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b4/1f5d483c254f75d01486d74926a6b9b90e915e68260a72f773585f97e6e1/dataclasses_avroschema-0.65.12-py3-none-any.whl", hash = "sha256:4f663ff0c92cb584f6e87f1aa7db22fad6127f7ffe7e806bae39cf36d938e005", size = 58644, upload-time = "2025-07-18T23:45:17.931Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d73b7ed6b1d8b027cfa704421d03a979e98626de1876cf4f056c0273e38a/dataclasses_avroschema-0.65.13-py3-none-any.whl", hash = "sha256:a183a4a16b45dd93d2d6853bed773d5e3db3a0d837398e0d696942486b5c92ee", size = 58668, upload-time = "2025-09-04T20:30:16.682Z" },
 ]
 
 [[package]]
@@ -455,7 +455,7 @@ wheels = [
 
 [[package]]
 name = "documenteer"
-version = "2.2.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -471,9 +471,9 @@ dependencies = [
     { name = "tomlkit" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/80/c9a616df7607b41ad132aaef8061ed0b1d471fcc535bd4de0afbcb9c3f5a/documenteer-2.2.0.tar.gz", hash = "sha256:78e320cd51d6cf8ea0072a560f04d4573d4e10478a21be281313d458d2b18212", size = 1268161, upload-time = "2025-08-06T18:59:25.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/34/917a21070b6d2ea33000f58c406f7778a085bce2987eba83dcf9f9f5eaeb/documenteer-2.3.0.tar.gz", hash = "sha256:24687448174c3cb0382d064aa2e71b25200520200ea8f230cc19c28f7f2f11c2", size = 1271750, upload-time = "2025-09-03T20:35:05.372Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/9a/a0160ca7817596be86ea29e95ced73ff623c6eeecb919df41e2b8506fd27/documenteer-2.2.0-py3-none-any.whl", hash = "sha256:145a57465f02e93c4a0c97677b90f58792a530d9c7bbf7324be29ca1878af70d", size = 705077, upload-time = "2025-08-06T18:59:23.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4a/408c64b720ac891fd665af6eb0af25606a238ec3c3c698dbdd52e6e38923/documenteer-2.3.0-py3-none-any.whl", hash = "sha256:ee154d7fa366565faaeb8aae0799a07005cc630dd477993eca72fbde00c65018", size = 705724, upload-time = "2025-09-03T20:35:03.964Z" },
 ]
 
 [package.optional-dependencies]
@@ -1442,7 +1442,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/5d/ab/34ec41718af73c001
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1451,9 +1451,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -1679,7 +1679,7 @@ dev = [
     { name = "respx" },
 ]
 docs = [
-    { name = "documenteer", extras = ["guide"], specifier = ">=2" },
+    { name = "documenteer", extras = ["guide"], specifier = ">=2.3" },
     { name = "scriv", extras = ["toml"], specifier = ">=1.5" },
 ]
 lint = [
@@ -1808,28 +1808,28 @@ requires-dist = [
 
 [[package]]
 name = "ruff"
-version = "0.12.11"
+version = "0.12.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/55/16ab6a7d88d93001e1ae4c34cbdcfb376652d761799459ff27c1dc20f6fa/ruff-0.12.11.tar.gz", hash = "sha256:c6b09ae8426a65bbee5425b9d0b82796dbb07cb1af045743c79bfb163001165d", size = 5347103, upload-time = "2025-08-28T13:59:08.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f0/e0965dd709b8cabe6356811c0ee8c096806bb57d20b5019eb4e48a117410/ruff-0.12.12.tar.gz", hash = "sha256:b86cd3415dbe31b3b46a71c598f4c4b2f550346d1ccf6326b347cc0c8fd063d6", size = 5359915, upload-time = "2025-09-04T16:50:18.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/a2/3b3573e474de39a7a475f3fbaf36a25600bfeb238e1a90392799163b64a0/ruff-0.12.11-py3-none-linux_armv6l.whl", hash = "sha256:93fce71e1cac3a8bf9200e63a38ac5c078f3b6baebffb74ba5274fb2ab276065", size = 11979885, upload-time = "2025-08-28T13:58:26.654Z" },
-    { url = "https://files.pythonhosted.org/packages/76/e4/235ad6d1785a2012d3ded2350fd9bc5c5af8c6f56820e696b0118dfe7d24/ruff-0.12.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b8e33ac7b28c772440afa80cebb972ffd823621ded90404f29e5ab6d1e2d4b93", size = 12742364, upload-time = "2025-08-28T13:58:30.256Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/0d/15b72c5fe6b1e402a543aa9d8960e0a7e19dfb079f5b0b424db48b7febab/ruff-0.12.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d69fb9d4937aa19adb2e9f058bc4fbfe986c2040acb1a4a9747734834eaa0bfd", size = 11920111, upload-time = "2025-08-28T13:58:33.677Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/c0/f66339d7893798ad3e17fa5a1e587d6fd9806f7c1c062b63f8b09dda6702/ruff-0.12.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:411954eca8464595077a93e580e2918d0a01a19317af0a72132283e28ae21bee", size = 12160060, upload-time = "2025-08-28T13:58:35.74Z" },
-    { url = "https://files.pythonhosted.org/packages/03/69/9870368326db26f20c946205fb2d0008988aea552dbaec35fbacbb46efaa/ruff-0.12.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a2c0a2e1a450f387bf2c6237c727dd22191ae8c00e448e0672d624b2bbd7fb0", size = 11799848, upload-time = "2025-08-28T13:58:38.051Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8c/dd2c7f990e9b3a8a55eee09d4e675027d31727ce33cdb29eab32d025bdc9/ruff-0.12.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ca4c3a7f937725fd2413c0e884b5248a19369ab9bdd850b5781348ba283f644", size = 13536288, upload-time = "2025-08-28T13:58:40.046Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/30/d5496fa09aba59b5e01ea76775a4c8897b13055884f56f1c35a4194c2297/ruff-0.12.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4d1df0098124006f6a66ecf3581a7f7e754c4df7644b2e6704cd7ca80ff95211", size = 14490633, upload-time = "2025-08-28T13:58:42.285Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/2f/81f998180ad53445d403c386549d6946d0748e536d58fce5b5e173511183/ruff-0.12.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a8dd5f230efc99a24ace3b77e3555d3fbc0343aeed3fc84c8d89e75ab2ff793", size = 13888430, upload-time = "2025-08-28T13:58:44.641Z" },
-    { url = "https://files.pythonhosted.org/packages/87/71/23a0d1d5892a377478c61dbbcffe82a3476b050f38b5162171942a029ef3/ruff-0.12.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4dc75533039d0ed04cd33fb8ca9ac9620b99672fe7ff1533b6402206901c34ee", size = 12913133, upload-time = "2025-08-28T13:58:47.039Z" },
-    { url = "https://files.pythonhosted.org/packages/80/22/3c6cef96627f89b344c933781ed38329bfb87737aa438f15da95907cbfd5/ruff-0.12.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fc58f9266d62c6eccc75261a665f26b4ef64840887fc6cbc552ce5b29f96cc8", size = 13169082, upload-time = "2025-08-28T13:58:49.157Z" },
-    { url = "https://files.pythonhosted.org/packages/05/b5/68b3ff96160d8b49e8dd10785ff3186be18fd650d356036a3770386e6c7f/ruff-0.12.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:5a0113bd6eafd545146440225fe60b4e9489f59eb5f5f107acd715ba5f0b3d2f", size = 13139490, upload-time = "2025-08-28T13:58:51.593Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b9/050a3278ecd558f74f7ee016fbdf10591d50119df8d5f5da45a22c6afafc/ruff-0.12.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0d737b4059d66295c3ea5720e6efc152623bb83fde5444209b69cd33a53e2000", size = 11958928, upload-time = "2025-08-28T13:58:53.943Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bc/93be37347db854806904a43b0493af8d6873472dfb4b4b8cbb27786eb651/ruff-0.12.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:916fc5defee32dbc1fc1650b576a8fed68f5e8256e2180d4d9855aea43d6aab2", size = 11764513, upload-time = "2025-08-28T13:58:55.976Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a1/1471751e2015a81fd8e166cd311456c11df74c7e8769d4aabfbc7584c7ac/ruff-0.12.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c984f07d7adb42d3ded5be894fb4007f30f82c87559438b4879fe7aa08c62b39", size = 12745154, upload-time = "2025-08-28T13:58:58.16Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/2542b14890d0f4872dd81b7b2a6aed3ac1786fae1ce9b17e11e6df9e31e3/ruff-0.12.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e07fbb89f2e9249f219d88331c833860489b49cdf4b032b8e4432e9b13e8a4b9", size = 13227653, upload-time = "2025-08-28T13:59:00.276Z" },
-    { url = "https://files.pythonhosted.org/packages/22/16/2fbfc61047dbfd009c58a28369a693a1484ad15441723be1cd7fe69bb679/ruff-0.12.11-py3-none-win32.whl", hash = "sha256:c792e8f597c9c756e9bcd4d87cf407a00b60af77078c96f7b6366ea2ce9ba9d3", size = 11944270, upload-time = "2025-08-28T13:59:02.347Z" },
-    { url = "https://files.pythonhosted.org/packages/08/a5/34276984705bfe069cd383101c45077ee029c3fe3b28225bf67aa35f0647/ruff-0.12.11-py3-none-win_amd64.whl", hash = "sha256:a3283325960307915b6deb3576b96919ee89432ebd9c48771ca12ee8afe4a0fd", size = 13046600, upload-time = "2025-08-28T13:59:04.751Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a8/001d4a7c2b37623a3fd7463208267fb906df40ff31db496157549cfd6e72/ruff-0.12.11-py3-none-win_arm64.whl", hash = "sha256:bae4d6e6a2676f8fb0f98b74594a048bae1b944aab17e9f5d504062303c6dbea", size = 12135290, upload-time = "2025-08-28T13:59:06.933Z" },
+    { url = "https://files.pythonhosted.org/packages/09/79/8d3d687224d88367b51c7974cec1040c4b015772bfbeffac95face14c04a/ruff-0.12.12-py3-none-linux_armv6l.whl", hash = "sha256:de1c4b916d98ab289818e55ce481e2cacfaad7710b01d1f990c497edf217dafc", size = 12116602, upload-time = "2025-09-04T16:49:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c3/6e599657fe192462f94861a09aae935b869aea8a1da07f47d6eae471397c/ruff-0.12.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7acd6045e87fac75a0b0cdedacf9ab3e1ad9d929d149785903cff9bb69ad9727", size = 12868393, upload-time = "2025-09-04T16:49:23.043Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d2/9e3e40d399abc95336b1843f52fc0daaceb672d0e3c9290a28ff1a96f79d/ruff-0.12.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:abf4073688d7d6da16611f2f126be86523a8ec4343d15d276c614bda8ec44edb", size = 12036967, upload-time = "2025-09-04T16:49:26.04Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/03/6816b2ed08836be272e87107d905f0908be5b4a40c14bfc91043e76631b8/ruff-0.12.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:968e77094b1d7a576992ac078557d1439df678a34c6fe02fd979f973af167577", size = 12276038, upload-time = "2025-09-04T16:49:29.056Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d5/707b92a61310edf358a389477eabd8af68f375c0ef858194be97ca5b6069/ruff-0.12.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42a67d16e5b1ffc6d21c5f67851e0e769517fb57a8ebad1d0781b30888aa704e", size = 11901110, upload-time = "2025-09-04T16:49:32.07Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/3d/f8b1038f4b9822e26ec3d5b49cf2bc313e3c1564cceb4c1a42820bf74853/ruff-0.12.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b216ec0a0674e4b1214dcc998a5088e54eaf39417327b19ffefba1c4a1e4971e", size = 13668352, upload-time = "2025-09-04T16:49:35.148Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0e/91421368ae6c4f3765dd41a150f760c5f725516028a6be30e58255e3c668/ruff-0.12.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:59f909c0fdd8f1dcdbfed0b9569b8bf428cf144bec87d9de298dcd4723f5bee8", size = 14638365, upload-time = "2025-09-04T16:49:38.892Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/88f3f06a142f58ecc8ecb0c2fe0b82343e2a2b04dcd098809f717cf74b6c/ruff-0.12.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9ac93d87047e765336f0c18eacad51dad0c1c33c9df7484c40f98e1d773876f5", size = 14060812, upload-time = "2025-09-04T16:49:42.732Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fc/8962e7ddd2e81863d5c92400820f650b86f97ff919c59836fbc4c1a6d84c/ruff-0.12.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01543c137fd3650d322922e8b14cc133b8ea734617c4891c5a9fccf4bfc9aa92", size = 13050208, upload-time = "2025-09-04T16:49:46.434Z" },
+    { url = "https://files.pythonhosted.org/packages/53/06/8deb52d48a9a624fd37390555d9589e719eac568c020b27e96eed671f25f/ruff-0.12.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afc2fa864197634e549d87fb1e7b6feb01df0a80fd510d6489e1ce8c0b1cc45", size = 13311444, upload-time = "2025-09-04T16:49:49.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/81/de5a29af7eb8f341f8140867ffb93f82e4fde7256dadee79016ac87c2716/ruff-0.12.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0c0945246f5ad776cb8925e36af2438e66188d2b57d9cf2eed2c382c58b371e5", size = 13279474, upload-time = "2025-09-04T16:49:53.465Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/d9577fdeaf791737ada1b4f5c6b59c21c3326f3f683229096cccd7674e0c/ruff-0.12.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a0fbafe8c58e37aae28b84a80ba1817f2ea552e9450156018a478bf1fa80f4e4", size = 12070204, upload-time = "2025-09-04T16:49:56.882Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/a910078284b47fad54506dc0af13839c418ff704e341c176f64e1127e461/ruff-0.12.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:b9c456fb2fc8e1282affa932c9e40f5ec31ec9cbb66751a316bd131273b57c23", size = 11880347, upload-time = "2025-09-04T16:49:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/df/58/30185fcb0e89f05e7ea82e5817b47798f7fa7179863f9d9ba6fd4fe1b098/ruff-0.12.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5f12856123b0ad0147d90b3961f5c90e7427f9acd4b40050705499c98983f489", size = 12891844, upload-time = "2025-09-04T16:50:02.591Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/28a8dacce4855e6703dcb8cdf6c1705d0b23dd01d60150786cd55aa93b16/ruff-0.12.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:26a1b5a2bf7dd2c47e3b46d077cd9c0fc3b93e6c6cc9ed750bd312ae9dc302ee", size = 13360687, upload-time = "2025-09-04T16:50:05.8Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fa/05b6428a008e60f79546c943e54068316f32ec8ab5c4f73e4563934fbdc7/ruff-0.12.12-py3-none-win32.whl", hash = "sha256:173be2bfc142af07a01e3a759aba6f7791aa47acf3604f610b1c36db888df7b1", size = 12052870, upload-time = "2025-09-04T16:50:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/85/60/d1e335417804df452589271818749d061b22772b87efda88354cf35cdb7a/ruff-0.12.12-py3-none-win_amd64.whl", hash = "sha256:e99620bf01884e5f38611934c09dd194eb665b0109104acae3ba6102b600fd0d", size = 13178016, upload-time = "2025-09-04T16:50:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7e/61c42657f6e4614a4258f1c3b0c5b93adc4d1f8575f5229d1906b483099b/ruff-0.12.12-py3-none-win_arm64.whl", hash = "sha256:2a8199cab4ce4d72d158319b63370abf60991495fb733db96cd923a34c52d093", size = 12256762, upload-time = "2025-09-04T16:50:15.737Z" },
 ]
 
 [[package]]
@@ -1890,15 +1890,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.35.2"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/79/0ecb942f3f1ad26c40c27f81ff82392d85c01d26a45e3c72c2b37807e680/sentry_sdk-2.35.2.tar.gz", hash = "sha256:e9e8f3c795044beb59f2c8f4c6b9b0f9779e5e604099882df05eec525e782cc6", size = 343377, upload-time = "2025-09-01T11:00:58.633Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/ac/52fcbba981793d3c90807b79cf6fa130cd25a54d152e653da3ed6d5defef/sentry_sdk-2.36.0.tar.gz", hash = "sha256:af9260e8155e41e8217615a453828e98aa40740865ac4b16b1ccb6a63b4b2e31", size = 343655, upload-time = "2025-09-04T07:56:37.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/91/a43308dc82a0e32d80cd0dfdcfca401ecbd0f431ab45f24e48bb97b7800d/sentry_sdk-2.35.2-py2.py3-none-any.whl", hash = "sha256:38c98e3cbb620dd3dd80a8d6e39c753d453dd41f8a9df581b0584c19a52bc926", size = 363975, upload-time = "2025-09-01T11:00:56.574Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/41ea723cb40f036d699cd954e2894fe7a044b0fd9a0e6bd881b1c9dda14e/sentry_sdk-2.36.0-py2.py3-none-any.whl", hash = "sha256:0f95586a141068d215376e5bf8ebd279e126f7f42805e9570190ef82a7e232b3", size = 364905, upload-time = "2025-09-04T07:56:36.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add an initial user guide, server REST API documentation, and client API documentation. Add the `docs` session to the nox configuration to build the documentation.

Split the client exceptions into a separate file instead of bundling them with the client.