### PR TITLE
DM-52228: Trigger documentation builds on more files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,8 @@ jobs:
             docs:
               - "CHANGELOG.md"
               - "docs/**"
+              - "src/repertoire/main.py"
+              - "client/src/rubin/repertoire/**"
             docs-specific:
               - "CHANGELOG.md"
               - "docs/**"


### PR DESCRIPTION
Trigger a documentation build if any of the client code changed (since it contributes to API documentation) or if `main.py` changed in the server (since it builds the server REST API).