### PR TITLE
DM-52228: Add docs-linkcheck nox session

### DIFF
--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,7 +1,7 @@
 .. _Butler: https://pipelines.lsst.io/modules/lsst.daf.butler/index.html
 .. _Click: https://click.palletsprojects.com/
 .. _HTTPX: https://www.python-httpx.org/
-.. _mypy: http://www.mypy-lang.org
+.. _mypy: https://www.mypy-lang.org
 .. _nox: https://nox.thea.codes/en/stable/index.html
 .. _Phalanx: https://phalanx.lsst.io/
 .. _pre-commit: https://pre-commit.com

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -7,7 +7,7 @@ This information is only useful for maintainers.
 
 Repertoire's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
 When a semantic version tag is pushed to GitHub, the Repertoire client is `released to PyPI`_ with that version.
-Similarly, documentation is built and pushed for each version (see https://repertoire.lsst.io/v).
+Similarly, documentation is built and pushed for each version (see https://repertoire.lsst.io/v/index.html).
 
 .. _`released to PyPI`: https://pypi.org/project/rubin-repertoire/
 .. _`ci.yaml`: https://github.com/lsst-sqre/repertoire/blob/main/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing
    The tag must follow the :pep:`440` specification since Repertoire uses setuptools_scm_ to set version metadata based on Git tags.
    In particular, don't prefix the tag with ``v``.
 
-   .. _setuptools_scm: https://github.com/pypa/setuptools_scm
+   .. _setuptools_scm: https://github.com/pypa/setuptools-scm
 
 2. Ensure the branch target is set appropriately (normally ``main``).
 

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -19,3 +19,10 @@ disable_primary_sidebars = ["index", "changelog"]
 
 [sphinx.intersphinx.projects]
 python = "https://docs.python.org/3/"
+
+[sphinx.linkcheck]
+ignore = [
+    # Generate redirects for authentication
+    '^https://github\.com/settings/developers$',
+    '^https://github\.com/.*/issues/new$',
+]


### PR DESCRIPTION
Add `docs-linkcheck` nox session to check the links in the documentation, used by the periodic CI check, and fix various broken links and redirects that it uncovered. Add the standard linkcheck ignore rules for authenticated links.