### PR TITLE
DM-52228: Fix various documentation and GitHub CI bugs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
-      - name: Run tox
+      - name: Run nox
         run: uv run --only-group=nox nox -s lint typing test
 
   changes:
@@ -168,7 +168,7 @@ jobs:
     needs: [test, docs, test-packaging]
     environment:
       name: pypi
-      url: https://pypi.org/p/safir
+      url: https://pypi.org/p/rubin-repertoire
     permissions:
       id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -1,6 +1,6 @@
-# This is a separate run of the Python test suite that doesn't cache the tox
-# environment and runs from a schedule. The purpose is to test compatibility
-# with the latest versions of dependencies.
+# This is a separate run of the Python test suite that updates dependencies
+# and runs from a schedule. The purpose is to test compatibility with the
+# latest versions of dependencies.
 
 name: Periodic CI
 

--- a/docs/dev/development.rst
+++ b/docs/dev/development.rst
@@ -99,14 +99,6 @@ For example:
 
    uv run nox -s test -- tests/client/service_test.py
 
-If you are interating on a specific test failure, you may want to pass the ``-R`` flag as well to skip the dependency installation step.
-This will make nox run somewhat faster, at the cost of not fixing out-of-date dependencies.
-For example:
-
-.. prompt:: bash
-
-   uv run nox -Rs test -- tests/client/service_test.py
-
 .. _dev-build-docs:
 
 Building documentation
@@ -123,15 +115,20 @@ The built documentation is located in the :file:`docs/_build/html` directory.
 
 Additional dependencies required only for the documentation build should be added to the ``docs`` dependency group in :file:`pyproject.toml`.
 
-Normally, Sphinx notices when input files have changed and rebuilds the documentation appropriately, but its caching logic is sometimes too aggressive and does not rebuild files that it should.
-This is often the case when files objects previously documented in the API documentation are removed.
-To force a rebuild of all of the documentation, ignoring the cache, use the ``docs-clean`` session:
+Documentation builds are incremental, and generate and use cached descriptions of the internal Python APIs.
+If you see errors in building the Python API documentation or have problems with changes to the documentation (particularly diagrams) not showing up, try a clean documentation build with:
 
 .. prompt:: bash
 
    uv run nox -s docs-clean
 
-Sometimes during development it's necessary to rebuild the documentation without the Sphinx
+This will be slower, but it will ensure that the documentation build doesn't rely on any cached data.
+
+To check the documentation for broken links, run:
+
+.. code-block:: sh
+
+   uv run nox -s docs-linkcheck
 
 .. _dev-updating-dependencies:
 

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -53,7 +53,7 @@ Finally, create a PR from those changes and merge it before continuing with the 
 2. GitHub release and tag
 -------------------------
 
-Use `GitHub's Release feature <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__ to create releases and their corresponding Git tags.
+Create a release using `GitHub's Release feature <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`__:
 
 1. For the tag, enter the version number of the release in the :guilabel:`Find or create a new tag` box in the dropdown under :guilabel:`Select tag`.
    The tag must follow the :pep:`440` specification since Repertoire uses setuptools_scm_ to set version metadata based on Git tags.
@@ -98,7 +98,7 @@ Developing on a release branch
 Once a release branch exists, it becomes the "main" branch for patches of that major-minor version.
 Pull requests should be based on, and merged into, the release branch.
 
-If the development on the release branch is a backport of commits on the ``main`` branch, use ``git cherry-pick`` to copy those commits into a new pull request against the release branch.
+If the development on the release branch is a backport of commits on the ``main`` branch, use :command:`git cherry-pick` to copy those commits into a new pull request against the release branch.
 
 Releasing from a release branch
 -------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dynamic = ["version"]
 [project.urls]
 Homepage = "https://repertoire.lsst.io"
 Source = "https://github.com/lsst-sqre/repertoire"
-
+"Change log" = "https://repertoire.lsst.io/changelog.html"
+"Issue tracker" = "https://github.com/lsst-sqre/repertoire/issues"
 
 [build-system]
 requires = [


### PR DESCRIPTION
* Use the correct module name for the PyPI upload
* Remove some mentions of tox in the GitHub Actions configuration
* Remove discussion of nox -R, since uv should make this irrelevant
* Clean up the development docs for building documentation
* Improve markup and tense in the release documentation
* Add more project metadata links