### PR TITLE
DM-52228: Stop using build-and-publish-to-pypi

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,7 +179,12 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Test building and publishing rubin-repertoire
-        uses: lsst-sqre/build-and-publish-to-pypi@v3
-        with:
-          working-directory: "client"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build the package
+        run: uv build --no-sources
+        working-directory: "client"
+
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
Apparently when uv workspaces are used, the package builds go to the top of the workspace and therefore `uv publish` must be run from the top of the workspace. Replace `build-and-publish-to-pypi` with manual build steps, since it doesn't support running `uv build` and `uv publish` in different directories.