### PR TITLE
DM-52453: Improve PyPI package building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,11 +157,11 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Test building and publishing rubin-repertoire
-        uses: lsst-sqre/build-and-publish-to-pypi@v3
-        with:
-          upload: false
-          working-directory: "client"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build the package
+        run: uv build --no-sources --package rubin-repertoire
 
   pypi:
     runs-on: ubuntu-latest
@@ -183,8 +183,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Build the package
-        run: uv build --no-sources
-        working-directory: "client"
+        run: uv build --no-sources --package rubin-repertoire
 
       - name: Publish
         run: uv publish


### PR DESCRIPTION
Use uv directly for the test-packaging step as well. Use the `--package` flag to `uv build` rather than changing directories.