### PR TITLE
DM-52453: Add support for discovery of InfluxDB databases

### DIFF
--- a/changelog.d/20250909_173345_rra_DM_52453.md
+++ b/changelog.d/20250909_173345_rra_DM_52453.md
@@ -1,0 +1,9 @@
+### Backwards-incompatible changes
+
+- Rename `RepertoireBuilder.build` to `RepertoireBuilder.build_discovery` now that there are multiple types of information that the builder can build.
+
+### New features
+
+- Add `RepertoireBuilder.build_influxdb` to construct InfluxDB discovery information, and a new class, `RepertoireBuilderWithSecrets`, with method `build_influxdb_with_credentials`, to build InfluxDB discovery information including credentials.
+- Add a new route, `/discovery/influxdb/{database}`, that returns InfluxDB discovery information with credentials. This route will be protected by Gafaelfawr authentication.
+- Add corresponding models and client methods `influxdb_databases` and `get_influxdb_connection_info` to retrieve the new information.

--- a/client/src/rubin/repertoire/__init__.py
+++ b/client/src/rubin/repertoire/__init__.py
@@ -1,11 +1,12 @@
 """Client, models, and URL construction for Repertoire."""
 
-from ._builder import RepertoireBuilder
+from ._builder import RepertoireBuilder, RepertoireBuilderWithSecrets
 from ._client import DiscoveryClient
 from ._config import (
     BaseRule,
     DataServiceRule,
     DatasetConfig,
+    InfluxDatabaseConfig,
     InternalServiceRule,
     RepertoireSettings,
     UiServiceRule,
@@ -16,7 +17,13 @@ from ._exceptions import (
     RepertoireValidationError,
     RepertoireWebError,
 )
-from ._models import Dataset, Discovery, ServiceUrls
+from ._models import (
+    Dataset,
+    Discovery,
+    InfluxDatabase,
+    InfluxDatabaseWithCredentials,
+    ServiceUrls,
+)
 
 __all__ = [
     "BaseRule",
@@ -25,8 +32,12 @@ __all__ = [
     "DatasetConfig",
     "Discovery",
     "DiscoveryClient",
+    "InfluxDatabase",
+    "InfluxDatabaseConfig",
+    "InfluxDatabaseWithCredentials",
     "InternalServiceRule",
     "RepertoireBuilder",
+    "RepertoireBuilderWithSecrets",
     "RepertoireError",
     "RepertoireSettings",
     "RepertoireUrlError",

--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from jinja2 import Template
-from pydantic import HttpUrl
+from pydantic import HttpUrl, SecretStr
 
 from ._config import (
     DataServiceRule,
@@ -12,9 +14,18 @@ from ._config import (
     Rule,
     UiServiceRule,
 )
-from ._models import Dataset, Discovery, ServiceUrls
+from ._models import (
+    Dataset,
+    Discovery,
+    InfluxDatabase,
+    InfluxDatabaseWithCredentials,
+    ServiceUrls,
+)
 
-__all__ = ["RepertoireBuilder"]
+__all__ = [
+    "RepertoireBuilder",
+    "RepertoireBuilderWithSecrets",
+]
 
 
 class RepertoireBuilder:
@@ -37,8 +48,13 @@ class RepertoireBuilder:
         self._base_context = {"base_hostname": config.base_hostname}
         self._datasets = {d.name for d in config.datasets}
 
-    def build(self) -> Discovery:
+    def build_discovery(self, base_url: str) -> Discovery:
         """Construct service discovery information from the configuration.
+
+        Parameters
+        ----------
+        base_url
+            Base URL for Repertoire internal links.
 
         Returns
         -------
@@ -48,7 +64,35 @@ class RepertoireBuilder:
         return Discovery(
             applications=sorted(self._config.applications),
             datasets=self._build_datasets(),
+            influxdb_databases=self._build_influxdb_databases(base_url),
             urls=self._build_urls(),
+        )
+
+    def build_influxdb(self, database: str) -> InfluxDatabase | None:
+        """Construct InfluxDB discovery information from the configuration.
+
+        Parameters
+        ----------
+        database
+            Name of the InfluxDB database.
+        include_credentials
+            If set to `True`, include credential information. This requires
+            the credential secrets be available locally to where this code
+            is running, at the configured paths.
+
+        Returns
+        -------
+        InfluxDatabase or None
+            InfluxDB connection information or `None` if no such InfluxDB
+            database was found.
+        """
+        influxdb = self._config.influxdb_databases.get(database)
+        if not influxdb:
+            return None
+        return InfluxDatabase(
+            url=influxdb.url,
+            database=influxdb.database,
+            schema_registry=influxdb.schema_registry,
         )
 
     def _build_datasets(self) -> list[Dataset]:
@@ -59,6 +103,13 @@ class RepertoireBuilder:
             if name in self._config.butler_configs:
                 dataset.butler_config = self._config.butler_configs[name]
         return datasets
+
+    def _build_influxdb_databases(self, base_url: str) -> dict[str, HttpUrl]:
+        """Construct the URLs to credentials for InfluxDB databases."""
+        return {
+            k: HttpUrl(base_url.rstrip("/") + f"/discovery/influxdb/{k}")
+            for k, v in sorted(self._config.influxdb_databases.items())
+        }
 
     def _build_urls(self) -> ServiceUrls:
         """Construct the service URLs for an environment."""
@@ -104,3 +155,59 @@ class RepertoireBuilder:
                 urls.internal[name] = HttpUrl(template.render(**context))
             case UiServiceRule():
                 urls.ui[name] = HttpUrl(template.render(**context))
+
+
+class RepertoireBuilderWithSecrets(RepertoireBuilder):
+    """Construct service discovery from configuration with secrets.
+
+    This class is identical to `RepertoireBuilder` with the addition of local
+    secrets. This allows it to build discovery information that requires
+    secrets, such as InfluxDB connection information with credentials.
+
+    Parameters
+    ----------
+    config
+        Repertoire configuration.
+    secrets_root
+        Root path to where Repertoire secrets are stored.
+    """
+
+    def __init__(
+        self, config: RepertoireSettings, secrets_root: str | Path
+    ) -> None:
+        super().__init__(config)
+        self._secrets_root = Path(secrets_root)
+
+    def build_influxdb_with_credentials(
+        self, database: str
+    ) -> InfluxDatabaseWithCredentials | None:
+        """Construct InfluxDB discovery information with credentials.
+
+        The files referenced in the password paths must exist locally when
+        calling this method. This will be the case for the running Repertoire
+        service but not when the library is being called outside of the
+        service, such as when building static information.
+
+        Parameters
+        ----------
+        database
+            Name of the InfluxDB database.
+
+        Returns
+        -------
+        InfluxDatabase or None
+            InfluxDB connection information or `None` if no such InfluxDB
+            database was found.
+        """
+        influxdb = self._config.influxdb_databases.get(database)
+        if not influxdb:
+            return None
+        password_path = self._secrets_root / influxdb.password_key
+        password = password_path.read_text()
+        return InfluxDatabaseWithCredentials(
+            url=influxdb.url,
+            database=influxdb.database,
+            username=influxdb.username,
+            password=SecretStr(password.rstrip("\n")),
+            schema_registry=influxdb.schema_registry,
+        )

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 __all__ = [
     "DatasetConfig",
+    "InfluxDatabaseConfig",
     "RepertoireSettings",
     "Rule",
 ]
@@ -29,6 +30,66 @@ class DatasetConfig(BaseModel):
         Field(
             title="Name",
             description="Human-readable name of the dataset",
+        ),
+    ]
+
+
+class InfluxDatabaseConfig(BaseModel):
+    """Configuration for an InfluxDB database.
+
+    Since these vary by environment and may be accessible across environments,
+    they need to be specified separately in each environment.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", validate_by_name=True
+    )
+
+    url: Annotated[
+        HttpUrl,
+        Field(
+            title="InfluxDB URL",
+            description="URL of InfluxDB service",
+            examples=["https://example.cloud/influxdb/"],
+        ),
+    ]
+
+    database: Annotated[
+        str,
+        Field(
+            title="Name of InfluxDB database",
+            description="Name of database to include in queries",
+            examples=["efd", "lsst.square.metrics"],
+        ),
+    ]
+
+    username: Annotated[
+        str,
+        Field(
+            title="Client username",
+            description="Username to send for authentication",
+            examples=["efdreader"],
+        ),
+    ]
+
+    password_key: Annotated[
+        str,
+        Field(
+            title="Secret key containing password",
+            description=(
+                "Set this to the key of the secret containing the password"
+                " for this InfluxDB database"
+            ),
+            examples=["influxdb_efd-password"],
+        ),
+    ]
+
+    schema_registry: Annotated[
+        HttpUrl,
+        Field(
+            title="Schema registry URL",
+            description="URL of corresponding Confluent schema registry",
+            examples=["https://example.cloud/schema-registry"],
         ),
     ]
 
@@ -139,6 +200,18 @@ class RepertoireSettings(BaseSettings):
             description="Metadata about available datasets",
         ),
     ] = []
+
+    influxdb_databases: Annotated[
+        dict[str, InfluxDatabaseConfig],
+        Field(
+            title="InfluxDB databases",
+            description=(
+                "Mapping of short database names to InfluxDB database"
+                " connection information for databases accessible from this"
+                " Phalanx environment"
+            ),
+        ),
+    ] = {}
 
     rules: Annotated[
         dict[str, list[Rule]],

--- a/docs/_rst_epilog.rst
+++ b/docs/_rst_epilog.rst
@@ -1,7 +1,9 @@
 .. _Butler: https://pipelines.lsst.io/modules/lsst.daf.butler/index.html
 .. _Click: https://click.palletsprojects.com/
+.. _Gafaelfawr: https://gafaelfawr.lsst.io/
 .. _HTTPX: https://www.python-httpx.org/
 .. _mypy: https://www.mypy-lang.org
+.. _Nublado: https://nublado.lsst.io/
 .. _nox: https://nox.thea.codes/en/stable/index.html
 .. _Phalanx: https://phalanx.lsst.io/
 .. _pre-commit: https://pre-commit.com

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -18,6 +18,7 @@ rst_epilog_file = "_rst_epilog.rst"
 disable_primary_sidebars = ["index", "changelog"]
 
 [sphinx.intersphinx.projects]
+aioinflux = "https://aioinflux.readthedocs.io/en/stable/"
 python = "https://docs.python.org/3/"
 
 [sphinx.linkcheck]

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -19,6 +19,7 @@ Consumers in other languages, such as JavaScript, can use the Repertoire server 
    initialization
    services
    datasets
+   influxdb
    applications
 
 .. toctree::

--- a/docs/user-guide/influxdb.rst
+++ b/docs/user-guide/influxdb.rst
@@ -1,0 +1,66 @@
+:og:description: Getting InfluxDB connection information.
+
+.. py:currentmodule:: rubin.repertoire
+
+#######################################
+Getting InfluxDB connection information
+#######################################
+
+Repertoire supports obtaining connection information for InfluxDB databases.
+Unlike other service discovery calls, the connection information includes credentials and therefore this API requires authentication.
+Also unlike other service discovery calls, the InfluxDB database may not be in the same Phalanx environment.
+
+Listing available databases
+===========================
+
+To get a list of InfluxDB databases for which connection information is available, call `DiscoveryClient.influxdb_databases`:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient()
+   databases = await discovery.influxdb_databases()
+
+The resulting names are short, human-readable names that can be passed as the ``database`` parameter to `DiscoveryClient.get_influxdb_connection_info` as described below.
+
+Getting connection information
+==============================
+
+Getting the connection information for a specific database requires authentication, since the returned information includes the username and password.
+
+First, obtain a Gafaelfawr_ token.
+Inside a service, normally this should be a delegated token received as part of a request and used to act on behalf of the user.
+See the `Gafaelfawr documentation on delegated tokens <https://gafaelfawr.lsst.io/user-guide/gafaelfawringress.html#requesting-delegated-tokens>`__ for more information.
+In other environments, this may be a user token created through the token UI, or a notebook token created by Nublado_.
+
+Then, call `DiscoveryClient.get_influxdb_connection_info` with the name of the database (possibly obtained via `DiscoveryClient.influxdb_databases`) and that token:
+
+.. code-block:: python
+
+   from rubin.repertoire import DiscoveryClient
+
+
+   discovery = DiscoveryClient()
+   token = "..."  # obtained from somewhere else
+   info = await discovery.get_influxdb_connection_info("some_database", token)
+
+The resulting object has the following fields:
+
+``url``
+    The URL of the InfluxDB service for this database.
+    This is a ``pydantic.HttpUrl`` without authentication information.
+    Use the ``host``, ``port``, and ``path`` attributes of the URL if you need those components separately (for the constructor of `aioinflux.client.InfluxDBClient`, for example).
+
+``database``
+    The name of the InfluxDB database to use for queries.
+
+``username``
+    Username with which to authenticate.
+
+``password``
+    Password with which to authenticate.
+
+``schema_registry``
+    The URL (as a string) of the associated `Confluent Kafka Schema Registry <https://docs.confluent.io/platform/current/schema-registry/index.html>`__ that contains schema information for this database.

--- a/src/repertoire/constants.py
+++ b/src/repertoire/constants.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-__all__ = ["CONFIG_PATH"]
+__all__ = ["CONFIG_PATH", "SECRETS_PATH"]
 
 CONFIG_PATH = "/etc/repertoire/config.yaml"
 """Default configuration path."""
+
+SECRETS_PATH = "/etc/repertoire/secrets"
+"""Default path to secrets, containing one file per secrets key."""

--- a/src/repertoire/dependencies/builder.py
+++ b/src/repertoire/dependencies/builder.py
@@ -1,0 +1,49 @@
+"""Cache the Repertoire builder."""
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends
+
+from rubin.repertoire import RepertoireBuilderWithSecrets
+
+from ..config import Config
+from .config import config_dependency
+
+__all__ = ["BuilderDependency", "builder_dependency"]
+
+
+class BuilderDependency:
+    """Construct and cache the Repertoire builder."""
+
+    def __init__(self) -> None:
+        self._secrets_root: str | Path | None = None
+        self._builder: RepertoireBuilderWithSecrets | None = None
+        self._old_config: Config | None = None
+
+    async def __call__(
+        self,
+        config: Annotated[Config, Depends(config_dependency)],
+    ) -> RepertoireBuilderWithSecrets:
+        """Return the cached Repertoire builder."""
+        if self._secrets_root is None:
+            raise AssertionError("Builder dependency not initialized")
+        if not self._builder or config != self._old_config:
+            secrets = self._secrets_root
+            self._builder = RepertoireBuilderWithSecrets(config, secrets)
+            self._old_config = config
+        return self._builder
+
+    def initialize(self, secrets_root: str | Path) -> None:
+        """Create the Repertoire builder.
+
+        Parameters
+        ----------
+        secrets_root
+            Root path to the mounted Repertoire secret.
+        """
+        self._secrets_root = secrets_root
+
+
+builder_dependency = BuilderDependency()
+"""The dependency that will return the Repertoire builder."""

--- a/src/repertoire/dependencies/discovery.py
+++ b/src/repertoire/dependencies/discovery.py
@@ -2,12 +2,11 @@
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, Request
 
 from rubin.repertoire import Discovery, RepertoireBuilder
 
-from ..config import Config
-from .config import config_dependency
+from .builder import builder_dependency
 
 __all__ = ["DiscoveryDependency", "discovery_dependency"]
 
@@ -22,13 +21,18 @@ class DiscoveryDependency:
 
     def __init__(self) -> None:
         self._discovery: Discovery | None = None
+        self._old_builder: RepertoireBuilder | None = None
 
     async def __call__(
-        self, config: Annotated[Config, Depends(config_dependency)]
+        self,
+        builder: Annotated[RepertoireBuilder, Depends(builder_dependency)],
+        request: Request,
     ) -> Discovery:
         """Generate discovery information if needed and return it."""
-        if not self._discovery:
-            self._discovery = RepertoireBuilder(config).build()
+        if not self._discovery or builder != self._old_builder:
+            base_url = request.url_for("get_root")
+            self._discovery = builder.build_discovery(str(base_url))
+            self._old_builder = builder
         return self._discovery
 
 

--- a/src/repertoire/exceptions.py
+++ b/src/repertoire/exceptions.py
@@ -1,0 +1,15 @@
+"""Custom exceptions for the Repertoire server."""
+
+from __future__ import annotations
+
+from fastapi import status
+from safir.fastapi import ClientRequestError
+
+__all__ = ["DatabaseNotFoundError"]
+
+
+class DatabaseNotFoundError(ClientRequestError):
+    """Requested InfluxDB database not found."""
+
+    error = "database_not_found"
+    status_code = status.HTTP_404_NOT_FOUND

--- a/src/repertoire/handlers/external.py
+++ b/src/repertoire/handlers/external.py
@@ -4,13 +4,20 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from safir.metadata import get_metadata
+from safir.models import ErrorLocation
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from rubin.repertoire import Discovery
+from rubin.repertoire import (
+    Discovery,
+    InfluxDatabaseWithCredentials,
+    RepertoireBuilderWithSecrets,
+)
 
 from ..config import Config
+from ..dependencies.builder import builder_dependency
 from ..dependencies.config import config_dependency
 from ..dependencies.discovery import discovery_dependency
+from ..exceptions import DatabaseNotFoundError
 from ..models import Index
 
 __all__ = ["external_router"]
@@ -24,7 +31,7 @@ external_router = APIRouter(route_class=SlackRouteErrorHandler)
     response_model_exclude_none=True,
     summary="Application metadata",
 )
-async def get_index(
+async def get_root(
     config: Annotated[Config, Depends(config_dependency)],
 ) -> Index:
     metadata = get_metadata(
@@ -42,3 +49,21 @@ async def get_discovery(
     discovery: Annotated[Discovery, Depends(discovery_dependency)],
 ) -> Discovery:
     return discovery
+
+
+@external_router.get(
+    "/discovery/influxdb/{database}",
+    response_model_exclude_none=True,
+    summary="InfluxDB connection information",
+)
+async def get_influxdb(
+    database: str,
+    builder: Annotated[
+        RepertoireBuilderWithSecrets, Depends(builder_dependency)
+    ],
+) -> InfluxDatabaseWithCredentials:
+    result = builder.build_influxdb_with_credentials(database)
+    if result is None:
+        msg = f"Database {database} not found"
+        raise DatabaseNotFoundError(msg, ErrorLocation.path, ["database"])
+    return result

--- a/tests/client/builder_test.py
+++ b/tests/client/builder_test.py
@@ -2,14 +2,60 @@
 
 from __future__ import annotations
 
-from rubin.repertoire import RepertoireBuilder, RepertoireSettings
+from rubin.repertoire import (
+    RepertoireBuilder,
+    RepertoireBuilderWithSecrets,
+    RepertoireSettings,
+)
 
+from ..support.constants import TEST_BASE_URL
 from ..support.data import data_path, read_test_json
 
 
-def test_builder() -> None:
+def test_build_discovery() -> None:
     config_path = data_path("config/phalanx.yaml")
+    base_url = TEST_BASE_URL.rstrip("/") + "/repertoire"
     config = RepertoireSettings.from_file(config_path)
-    output = RepertoireBuilder(config).build()
+    output = RepertoireBuilder(config).build_discovery(base_url)
     output_json = output.model_dump(mode="json", exclude_none=True)
     assert output_json == read_test_json("output/phalanx")
+
+
+def test_build_influxdb() -> None:
+    config_path = data_path("config/phalanx.yaml")
+    config = RepertoireSettings.from_file(config_path)
+    expected = read_test_json("output/idfdev_efd")
+
+    # This is the version without credentials, so username and password should
+    # not be included.
+    del expected["username"]
+    del expected["password"]
+
+    # Check the output.
+    output = RepertoireBuilder(config).build_influxdb("idfdev_efd")
+    assert output
+    assert output.model_dump(mode="json", exclude_none=True) == expected
+
+
+def test_build_influxdb_creds() -> None:
+    config_path = data_path("config/phalanx.yaml")
+    secrets_path = data_path("secrets")
+    config = RepertoireSettings.from_file(config_path)
+
+    # First test with a Path parameter to RepertoireBuilderWithSecrets and a
+    # secret file ending in a newline.
+    builder = RepertoireBuilderWithSecrets(config, secrets_path)
+    output = builder.build_influxdb_with_credentials("idfdev_efd")
+    assert output
+    output_json = output.model_dump(mode="json", exclude_none=True)
+    assert output_json == read_test_json("output/idfdev_efd")
+
+    # Now test with a str parameter and a secret file not ending in a newline.
+    builder = RepertoireBuilderWithSecrets(config, str(secrets_path))
+    output = builder.build_influxdb_with_credentials("idfdev_metrics")
+    assert output
+    output_json = output.model_dump(mode="json", exclude_none=True)
+    assert output_json == read_test_json("output/idfdev_metrics")
+
+    # Unknown InfluxDB databases should return None.
+    assert builder.build_influxdb("invalid") is None

--- a/tests/client/influxdb_test.py
+++ b/tests/client/influxdb_test.py
@@ -1,0 +1,54 @@
+"""Tests for the InfluxDB discovery client."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Request, Response
+
+from rubin.repertoire import DiscoveryClient
+
+from ..support.constants import TEST_BASE_URL
+from ..support.data import read_test_json
+
+
+@pytest.mark.asyncio
+async def test_influxdb_databases(discovery_client: DiscoveryClient) -> None:
+    output = read_test_json("output/phalanx")
+    expected = list(output["influxdb_databases"].keys())
+    assert await discovery_client.influxdb_databases() == expected
+
+
+@pytest.mark.asyncio
+async def test_connection_info(discovery_client: DiscoveryClient) -> None:
+    client = discovery_client
+
+    for database in ("idfdev_efd", "idfdev_metrics"):
+        output = await client.get_influxdb_connection_info(database, "token")
+        assert output
+        output_json = output.model_dump(mode="json", exclude_none=True)
+        assert output_json == read_test_json(f"output/{database}")
+
+    assert await client.get_influxdb_connection_info("invalid", "t") is None
+
+
+@pytest.mark.asyncio
+async def test_authentication(respx_mock: respx.Router) -> None:
+    result = read_test_json("output/idfdev_efd")
+    discovery_url = f"{TEST_BASE_URL}repertoire/discovery"
+    influxdb_url = f"{TEST_BASE_URL}repertoire/discovery/influxdb/idfdev_efd"
+    token = "some-gafaelfawr-token"
+
+    def check_request(request: Request) -> Response:
+        assert request.headers["Authorization"] == f"Bearer {token}"
+        return Response(200, json=result)
+
+    discovery_response = Response(200, json=read_test_json("output/phalanx"))
+    respx_mock.get(discovery_url).mock(return_value=discovery_response)
+    respx_mock.get(influxdb_url).mock(side_effect=check_request)
+
+    discovery = DiscoveryClient(base_url=f"{TEST_BASE_URL}repertoire")
+    output = await discovery.get_influxdb_connection_info("idfdev_efd", token)
+    assert output
+    output_json = output.model_dump(mode="json", exclude_none=True)
+    assert output_json == result

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -35,6 +35,19 @@ datasets:
   - name: "dp02"
   - name: "dp03"
   - name: "dp1"
+influxdbDatabases:
+  idfdev_efd:
+    url: "https://data.example.com/influxdb/"
+    database: "efd"
+    username: "efdreader"
+    passwordKey: "idfdev_efd-password"
+    schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+  idfdev_metrics:
+    url: "https://data.example.com/influxdb/"
+    database: "lsst.square.metrics"
+    username: "efdreader"
+    passwordKey: "idfdev_metrics-password"
+    schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
 rules:
   argocd:
     - type: "ui"

--- a/tests/data/output/idfdev_efd.json
+++ b/tests/data/output/idfdev_efd.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://data.example.com/influxdb/",
+  "database": "efd",
+  "username": "efdreader",
+  "password": "some-password",
+  "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/"
+}

--- a/tests/data/output/idfdev_metrics.json
+++ b/tests/data/output/idfdev_metrics.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://data.example.com/influxdb/",
+  "database": "lsst.square.metrics",
+  "username": "efdreader",
+  "password": "other-password",
+  "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/"
+}

--- a/tests/data/output/minimal.json
+++ b/tests/data/output/minimal.json
@@ -1,0 +1,10 @@
+{
+  "applications": [],
+  "datasets": [],
+  "influxdb_databases": {},
+  "urls": {
+    "data": {},
+    "internal": {},
+    "ui": {}
+  }
+}

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -40,6 +40,10 @@
       "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
     }
   ],
+  "influxdb_databases": {
+    "idfdev_efd": "https://example.com/repertoire/discovery/influxdb/idfdev_efd",
+    "idfdev_metrics": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics"
+  },
   "urls": {
     "data": {
       "cutout": {

--- a/tests/data/secrets/idfdev_efd-password
+++ b/tests/data/secrets/idfdev_efd-password
@@ -1,0 +1,1 @@
+some-password

--- a/tests/data/secrets/idfdev_metrics-password
+++ b/tests/data/secrets/idfdev_metrics-password
@@ -1,0 +1,1 @@
+other-password


### PR DESCRIPTION
Add a separate Repertoire service route to return connection information for an InfluxDB database. This route will be authenticated since it includes the username and password in the response. Refactor the FastAPI dependencies to allow dynamic discovery of the root URL of the API and configuring the root path to secrets, and regenerate discovery information if the underlying configuration has changed.

Include a mapping of InfluxDB database names to the URLs for the connection information in the main service discovery information.

Add builder support for generating InfluxDB database connection information both with and without credentials. The version without credentials will be used later for static service discovery. Add client support for getting a list of InfluxDB database and retrieving their authentication information with credentials.