### PR TITLE
DM-52453: Rework the data model for datasets

### DIFF
--- a/changelog.d/20250910_092205_rra_DM_52453.md
+++ b/changelog.d/20250910_092205_rra_DM_52453.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- Change the input configuration for datasets to be a mapping of dataset label to metadata instead of a list, and add a mandatory `description` field for datasets.
+- Change the model for discovery information to return datasets as a mapping of label to metadata instead of a list of mappings with `name` keys.
+
+### New features
+
+- Add the `description` field to the model for datasets.

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -105,9 +105,8 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        for candidate in discovery.datasets:
-            if candidate.name == dataset and candidate.butler_config:
-                return str(candidate.butler_config)
+        if info := discovery.datasets.get(dataset):
+            return str(info.butler_config) if info.butler_config else None
         return None
 
     async def butler_repositories(self) -> dict[str, str]:
@@ -127,9 +126,9 @@ class DiscoveryClient:
         """
         discovery = await self._get_discovery()
         return {
-            d.name: str(d.butler_config)
-            for d in discovery.datasets
-            if d.butler_config is not None
+            k: str(v.butler_config)
+            for k, v in discovery.datasets.items()
+            if v.butler_config is not None
         }
 
     async def datasets(self) -> list[str]:
@@ -149,7 +148,7 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        return sorted(d.name for d in discovery.datasets)
+        return sorted(discovery.datasets.keys())
 
     async def get_influxdb_connection_info(
         self, database: str, token: str

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -25,11 +25,10 @@ class DatasetConfig(BaseModel):
         alias_generator=to_camel, extra="forbid", validate_by_name=True
     )
 
-    name: Annotated[
+    description: Annotated[
         str,
         Field(
-            title="Name",
-            description="Human-readable name of the dataset",
+            title="Description", description="Long description of the dataset"
         ),
     ]
 
@@ -194,12 +193,14 @@ class RepertoireSettings(BaseSettings):
     ] = {}
 
     datasets: Annotated[
-        list[DatasetConfig],
+        dict[str, DatasetConfig],
         Field(
             title="Datasets",
-            description="Metadata about available datasets",
+            description=(
+                "Mapping of dataset names to metadata about that dataset"
+            ),
         ),
-    ] = []
+    ] = {}
 
     influxdb_databases: Annotated[
         dict[str, InfluxDatabaseConfig],

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -18,15 +18,6 @@ __all__ = [
 class Dataset(BaseModel):
     """Discovery information about a single dataset."""
 
-    name: Annotated[
-        str,
-        Field(
-            title="Name",
-            description="Human-readable name of the dataset",
-            examples=["dp02", "dp1"],
-        ),
-    ]
-
     butler_config: Annotated[
         HttpUrl | None,
         Field(
@@ -40,6 +31,18 @@ class Dataset(BaseModel):
             ],
         ),
     ] = None
+
+    description: Annotated[
+        str,
+        Field(
+            title="Description",
+            description="Long description of the dataset",
+            examples=[
+                "Data Preview 1 contains the first image data from the"
+                " telescope during commissioning"
+            ],
+        ),
+    ]
 
 
 class InfluxDatabase(BaseModel):
@@ -175,13 +178,12 @@ class Discovery(BaseModel):
     ] = []
 
     datasets: Annotated[
-        list[Dataset],
+        dict[str, Dataset],
         Field(
             title="Datasets",
             description="All datasets available in the local environment",
-            examples=[["dp02", "dp1"]],
         ),
-    ] = []
+    ] = {}
 
     influxdb_databases: Annotated[
         dict[str, HttpUrl],
@@ -193,6 +195,7 @@ class Discovery(BaseModel):
                 " retrieve connection information. Requests to that URL will"
                 " require authentication."
             ),
+            examples=[{"efd": "https://example.com/discovery/influxdb/efd"}],
         ),
     ] = {}
 

--- a/tests/client/service_test.py
+++ b/tests/client/service_test.py
@@ -20,7 +20,7 @@ async def test_applications(discovery_client: DiscoveryClient) -> None:
 @pytest.mark.asyncio
 async def test_datasets(discovery_client: DiscoveryClient) -> None:
     output = read_test_json("output/phalanx")
-    expected = sorted(d["name"] for d in output["datasets"])
+    expected = sorted(output["datasets"].keys())
     assert await discovery_client.datasets() == expected
 
 
@@ -28,8 +28,8 @@ async def test_datasets(discovery_client: DiscoveryClient) -> None:
 async def test_butler_config_for(discovery_client: DiscoveryClient) -> None:
     output = read_test_json("output/phalanx")
     for dataset in output["datasets"]:
-        result = await discovery_client.butler_config_for(dataset["name"])
-        assert result == dataset.get("butler_config")
+        result = await discovery_client.butler_config_for(dataset)
+        assert result == output["datasets"][dataset].get("butler_config")
     assert await discovery_client.butler_config_for("unknown") is None
 
 
@@ -37,9 +37,9 @@ async def test_butler_config_for(discovery_client: DiscoveryClient) -> None:
 async def test_butler_repositories(discovery_client: DiscoveryClient) -> None:
     output = read_test_json("output/phalanx")
     expected = {
-        d["name"]: d["butler_config"]
-        for d in output["datasets"]
-        if d.get("butler_config") is not None
+        k: v["butler_config"]
+        for k, v in output["datasets"].items()
+        if v.get("butler_config") is not None
     }
     assert await discovery_client.butler_repositories() == expected
 

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -32,9 +32,23 @@ butlerConfigs:
   dp02: "https://data.example.com/api/butler/repo/dp02/butler.yaml"
   dp1: "https://data.example.com/api/butler/repo/dp1/butler.yaml"
 datasets:
-  - name: "dp02"
-  - name: "dp03"
-  - name: "dp1"
+  dp02:
+    description: >-
+      Data Preview 0.2 contains the image and catalog products of the Rubin
+      Science Pipelines v23 processing of the DESC Data Challenge 2
+      simulation, which covered 300 square degrees of the wide-fast-deep LSST
+      survey region over 5 years.
+  dp03:
+    description: >-
+      Data Preview 0.3 contains the catalog products of a Solar System Science
+      Collaboration simulation of the results of SSO analysis of the
+      wide-fast-deep data from the LSST dataset.
+  dp1:
+    description: >-
+      Data Preview 1 contains image and catalog products from the Rubin
+      Science Pipelines v29 processing of observations obtained with the LSST
+      Commissioning Camera of seven ~1 square degree fields, over seven weeks
+      in late 2024.
 influxdbDatabases:
   idfdev_efd:
     url: "https://data.example.com/influxdb/"

--- a/tests/data/output/minimal.json
+++ b/tests/data/output/minimal.json
@@ -1,6 +1,6 @@
 {
   "applications": [],
-  "datasets": [],
+  "datasets": {},
   "influxdb_databases": {},
   "urls": {
     "data": {},

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -27,19 +27,19 @@
     "vo-cutouts",
     "wobbly"
   ],
-  "datasets": [
-    {
-      "name": "dp02",
-      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml"
+  "datasets": {
+    "dp02": {
+      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml",
+      "description": "Data Preview 0.2 contains the image and catalog products of the Rubin Science Pipelines v23 processing of the DESC Data Challenge 2 simulation, which covered 300 square degrees of the wide-fast-deep LSST survey region over 5 years."
     },
-    {
-      "name": "dp03"
+    "dp03": {
+      "description": "Data Preview 0.3 contains the catalog products of a Solar System Science Collaboration simulation of the results of SSO analysis of the wide-fast-deep data from the LSST dataset."
     },
-    {
-      "name": "dp1",
-      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
+    "dp1": {
+      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml",
+      "description": "Data Preview 1 contains image and catalog products from the Rubin Science Pipelines v29 processing of observations obtained with the LSST Commissioning Camera of seven ~1 square degree fields, over seven weeks in late 2024."
     }
-  ],
+  },
   "influxdb_databases": {
     "idfdev_efd": "https://example.com/repertoire/discovery/influxdb/idfdev_efd",
     "idfdev_metrics": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics"


### PR DESCRIPTION
Change both the configuration and the output data model for datasets to be a mapping of labels to metadata instead of a list of mappings with `name` attributes. Add a mandatory `description` attribute.