### PR TITLE
DM-52453: Separate available datasets from metadata

### DIFF
--- a/changelog.d/20250910_094254_rra_DM_52453.md
+++ b/changelog.d/20250910_094254_rra_DM_52453.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Add new `availableDatasets` configuration parameter to list the datasets available in a given environment, allowing that list to be separated from shared metadata about all available datasets.

--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -97,6 +97,8 @@ class RepertoireBuilder:
         """Construct the datasets available in an environment."""
         results = {}
         for key, value in self._config.datasets.items():
+            if key not in self._config.available_datasets:
+                continue
             results[key] = Dataset(
                 butler_config=self._config.butler_configs.get(key),
                 description=value.description,
@@ -142,8 +144,9 @@ class RepertoireBuilder:
         context = self._base_context
         match rule:
             case DataServiceRule():
-                for dataset in rule.datasets or self._config.datasets.keys():
-                    if dataset not in self._config.datasets:
+                allowed = rule.datasets or self._config.available_datasets
+                for dataset in allowed:
+                    if dataset not in self._config.available_datasets:
                         continue
                     context = {**context, "dataset": dataset}
                     url = template.render(**context)

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -176,6 +176,14 @@ class RepertoireSettings(BaseSettings):
         ),
     ] = set()
 
+    available_datasets: Annotated[
+        set[str],
+        Field(
+            title="Available datasets",
+            description="Datasets available in this Phalanx environment",
+        ),
+    ] = set()
+
     base_hostname: Annotated[
         str,
         Field(

--- a/docs/user-guide/datasets.rst
+++ b/docs/user-guide/datasets.rst
@@ -7,9 +7,9 @@ Listing datasets
 ################
 
 To list all of the datasets available in the local environment, call `DiscoveryClient.datasets`.
-The result will be a list of the short dataset names.
+The result will be a list of the dataset labels.
 
-These names are the valid arguments for the dataset parameters to `DiscoveryClient.url_for_data_service` and `DiscoveryClient.butler_config_for` in that environment.
+These labels are the valid arguments for the dataset parameters to `DiscoveryClient.url_for_data_service` and `DiscoveryClient.butler_config_for` in that environment.
 
 For example:
 
@@ -26,9 +26,6 @@ For example:
            print(f"Cutout API for {dataset}: {url}")
        else:
            print(f"Cutouts for {dataset} not available")
-
-Currently, only the names of datasets are returned.
-More information about datasets will likely be available in future versions.
 
 Next steps
 ==========

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -27,6 +27,10 @@ applications:
   - "vault-secrets-operator"
   - "vo-cutouts"
   - "wobbly"
+availableDatasets:
+  - "dp02"
+  - "dp03"
+  - "dp1"
 baseHostname: "data.example.com"
 butlerConfigs:
   dp02: "https://data.example.com/api/butler/repo/dp02/butler.yaml"
@@ -49,6 +53,9 @@ datasets:
       Science Pipelines v29 processing of observations obtained with the LSST
       Commissioning Camera of seven ~1 square degree fields, over seven weeks
       in late 2024.
+  other:
+    description: >-
+      Test dataset not listed in availableDatasets.
 influxdbDatabases:
   idfdev_efd:
     url: "https://data.example.com/influxdb/"


### PR DESCRIPTION
Add a new `availableDatasets` configuration parameter to explicitly list the available datasets, separating that configuration from the metadata about the datasets. This allows dataset metadata to be maintained in `values.yaml` and selectively enabled in the per-environment values files.