### PR TITLE
DM-52453: Convert service URLs to rich objects

### DIFF
--- a/changelog.d/20250910_124235_rra_DM_52453.md
+++ b/changelog.d/20250910_124235_rra_DM_52453.md
@@ -1,0 +1,8 @@
+### Backwards-incompatible changes
+
+- Rename the `urls` field of discovery information to `services`.
+- Convert the values of the `data`, `internal`, and `ui` mappings to be full objects, moving the URL into the `url` field of that object. This creates room for additional fields in the future.
+
+### New features
+
+- Add an optional `openapi` key to service information for data and internal services, which contains a URL for the OpenAPI JSON schema if set. Add support for that field to the corresponding service generation rules.

--- a/client/src/rubin/repertoire/__init__.py
+++ b/client/src/rubin/repertoire/__init__.py
@@ -18,15 +18,23 @@ from ._exceptions import (
     RepertoireWebError,
 )
 from ._models import (
+    ApiService,
+    BaseService,
+    DataService,
     Dataset,
     Discovery,
     InfluxDatabase,
     InfluxDatabaseWithCredentials,
-    ServiceUrls,
+    InternalService,
+    Services,
+    UiService,
 )
 
 __all__ = [
+    "ApiService",
     "BaseRule",
+    "BaseService",
+    "DataService",
     "DataServiceRule",
     "Dataset",
     "DatasetConfig",
@@ -35,6 +43,7 @@ __all__ = [
     "InfluxDatabase",
     "InfluxDatabaseConfig",
     "InfluxDatabaseWithCredentials",
+    "InternalService",
     "InternalServiceRule",
     "RepertoireBuilder",
     "RepertoireBuilderWithSecrets",
@@ -43,6 +52,7 @@ __all__ = [
     "RepertoireUrlError",
     "RepertoireValidationError",
     "RepertoireWebError",
-    "ServiceUrls",
+    "Services",
+    "UiService",
     "UiServiceRule",
 ]

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -228,11 +228,11 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        urls = discovery.urls.data.get(service)
-        if not urls:
+        datasets = discovery.services.data.get(service)
+        if not datasets:
             return None
-        url = urls.get(dataset)
-        return str(url) if url is not None else None
+        info = datasets.get(dataset)
+        return str(info.url) if info else None
 
     async def url_for_internal_service(self, service: str) -> str | None:
         """Return the base API URL for a given internal service.
@@ -254,8 +254,8 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        url = discovery.urls.internal.get(service)
-        return str(url) if url is not None else None
+        info = discovery.services.internal.get(service)
+        return str(info.url) if info else None
 
     async def url_for_ui_service(self, service: str) -> str | None:
         """Return the base URL for a given UI service.
@@ -277,8 +277,8 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        url = discovery.urls.ui.get(service)
-        return str(url) if url is not None else None
+        info = discovery.services.ui.get(service)
+        return str(info.url) if info else None
 
     async def _get[T: BaseModel](
         self, url: str | HttpUrl, model: type[T], token: str | None = None

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -134,11 +134,27 @@ class DataServiceRule(BaseRule):
         ),
     ] = None
 
+    openapi: Annotated[
+        str | None,
+        Field(
+            title="OpenAPI schema template",
+            description="Template to generate the OpenAPI schema URL",
+        ),
+    ] = None
+
 
 class InternalServiceRule(BaseRule):
     """Rule for an internal Phalanx service not associated with a dataset."""
 
     type: Annotated[Literal["internal"], Field(title="Type of service")]
+
+    openapi: Annotated[
+        str | None,
+        Field(
+            title="OpenAPI schema template",
+            description="Template to generate the OpenAPI schema URL",
+        ),
+    ] = None
 
 
 class UiServiceRule(BaseRule):

--- a/tests/client/service_test.py
+++ b/tests/client/service_test.py
@@ -47,21 +47,23 @@ async def test_butler_repositories(discovery_client: DiscoveryClient) -> None:
 @pytest.mark.asyncio
 async def test_url_for(discovery_client: DiscoveryClient) -> None:
     output = read_test_json("output/phalanx")
-    urls = output["urls"]
+    services = output["services"]
 
-    for service, url in urls["internal"].items():
+    for service, info in services["internal"].items():
+        url = info["url"]
         assert await discovery_client.url_for_internal_service(service) == url
     assert await discovery_client.url_for_internal_service("unknown") is None
 
-    for service, url in urls["ui"].items():
+    for service, info in services["ui"].items():
+        url = info["url"]
         assert await discovery_client.url_for_ui_service(service) == url
     assert await discovery_client.url_for_ui_service("unknown") is None
 
     client = discovery_client
-    for service, mapping in urls["data"].items():
-        for dataset, url in mapping.items():
+    for service, mapping in services["data"].items():
+        for dataset, info in mapping.items():
             result = await client.url_for_data_service(service, dataset)
-            assert result == url
+            assert result == info["url"]
         assert await client.url_for_data_service(service, "unknown") is None
     assert await client.url_for_data_service("unknown", dataset) is None
 

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -78,14 +78,17 @@ rules:
     - type: "internal"
       name: "gafaelfawr"
       template: "https://{{base_hostname}}/auth/api/v1"
+      openapi: "https://{{base_hostname}}/auth/openapi.json"
   mobu:
     - type: "internal"
       name: "mobu"
       template: "https://{{base_hostname}}/mobu"
+      openapi: "https://{{base_hostname}}/mobu/openapi.json"
   noteburst:
     - type: "internal"
       name: "noteburst"
       template: "https://{{base_hostname}}/noteburst/v1"
+      openapi: "https://{{base_hostname}}/noteburst/openapi.json"
   nublado:
     - type: "ui"
       name: "nublado"
@@ -98,6 +101,7 @@ rules:
     - type: "internal"
       name: "semaphore"
       template: "https://{{base_hostname}}/semaphore"
+      openapi: "https://{{base_hostname}}/semaphore/openapi.json"
   sia:
     - type: "data"
       name: "sia"
@@ -105,6 +109,7 @@ rules:
         - "dp02"
         - "dp1"
       template: "https://{{base_hostname}}/api/sia/{{dataset}}"
+      openapi: "https://{{base_hostname}}/api/sia/openapi.json"
   ssotap:
     - type: "data"
       name: "tap"
@@ -122,10 +127,12 @@ rules:
     - type: "data"
       name: "cutout"
       template: "https://{{base_hostname}}/api/cutout"
+      openapi: "https://{{base_hostname}}/api/cutout/openapi.json"
   wobbly:
     - type: "internal"
       name: "wobbly"
       template: "https://{{base_hostname}}/wobbly"
+      openapi: "https://{{base_hostname}}/wobbly/openapi.json"
 subdomainRules:
   nublado:
     - type: "ui"

--- a/tests/data/output/minimal.json
+++ b/tests/data/output/minimal.json
@@ -2,7 +2,7 @@
   "applications": [],
   "datasets": {},
   "influxdb_databases": {},
-  "urls": {
+  "services": {
     "data": {},
     "internal": {},
     "ui": {}

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -44,34 +44,76 @@
     "idfdev_efd": "https://example.com/repertoire/discovery/influxdb/idfdev_efd",
     "idfdev_metrics": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics"
   },
-  "urls": {
+  "services": {
     "data": {
       "cutout": {
-        "dp02": "https://data.example.com/api/cutout",
-        "dp03": "https://data.example.com/api/cutout",
-        "dp1": "https://data.example.com/api/cutout"
+        "dp02": {
+          "url": "https://data.example.com/api/cutout",
+          "openapi": "https://data.example.com/api/cutout/openapi.json"
+        },
+        "dp03": {
+          "url": "https://data.example.com/api/cutout",
+          "openapi": "https://data.example.com/api/cutout/openapi.json"
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/cutout",
+          "openapi": "https://data.example.com/api/cutout/openapi.json"
+        }
       },
       "sia": {
-        "dp02": "https://data.example.com/api/sia/dp02",
-        "dp1": "https://data.example.com/api/sia/dp1"
+        "dp02": {
+          "url": "https://data.example.com/api/sia/dp02",
+          "openapi": "https://data.example.com/api/sia/openapi.json"
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/sia/dp1",
+          "openapi": "https://data.example.com/api/sia/openapi.json"
+        }
       },
       "tap": {
-        "dp02": "https://data.example.com/api/tap",
-        "dp03": "https://data.example.com/api/ssotap",
-        "dp1": "https://data.example.com/api/tap"
+        "dp02": {
+          "url": "https://data.example.com/api/tap"
+        },
+        "dp03": {
+          "url": "https://data.example.com/api/ssotap"
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/tap"
+        }
       }
     },
     "internal": {
-      "gafaelfawr": "https://data.example.com/auth/api/v1",
-      "mobu": "https://data.example.com/mobu",
-      "noteburst": "https://data.example.com/noteburst/v1",
-      "semaphore": "https://data.example.com/semaphore",
-      "wobbly": "https://data.example.com/wobbly"
+      "gafaelfawr": {
+        "url": "https://data.example.com/auth/api/v1",
+        "openapi": "https://data.example.com/auth/openapi.json"
+      },
+      "mobu": {
+        "url": "https://data.example.com/mobu",
+        "openapi": "https://data.example.com/mobu/openapi.json"
+      },
+      "noteburst": {
+        "url": "https://data.example.com/noteburst/v1",
+        "openapi": "https://data.example.com/noteburst/openapi.json"
+      },
+      "semaphore": {
+        "url": "https://data.example.com/semaphore",
+        "openapi": "https://data.example.com/semaphore/openapi.json"
+      },
+      "wobbly": {
+        "url": "https://data.example.com/wobbly",
+        "openapi": "https://data.example.com/wobbly/openapi.json"
+      }
     },
     "ui": {
-      "argocd": "https://data.example.com/argo-cd",
-      "nublado": "https://nb.data.example.com/nb",
-      "portal": "https://data.example.com/portal/app/"
+      "argocd": {
+        "url": "https://data.example.com/argo-cd"
+      },
+      "nublado": {
+        "url": "https://nb.data.example.com/nb"
+      },
+      "portal": {
+        "url": "https://data.example.com/portal/app/"
+      }
     }
   }
 }


### PR DESCRIPTION
Rather than returning mappings of service name to (optional) dataset name to a simple base URL, change the final value to a full object with a `url` key holding the URL. This creates room for future expansion of the data that's returned.

Add an `openapi` key holding the OpenAPI schema, if available, to data and internal services, and add the corresponding rule configuration to template that URL.

Rename the `urls` field to `services` now that it potentially contains more information than just URLs.