### PR TITLE
DM-52490: Allow more disabled HiPS configuration

### DIFF
--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -111,8 +111,8 @@ class RepertoireBuilder:
             if base_url and self._config.hips:
                 if key in self._config.hips.datasets:
                     path_prefix = self._config.hips.path_prefix
-                    base_url = base_url.rstrip("/") + path_prefix
-                    hips = HttpUrl(base_url + f"/{key}/list")
+                    hips_base_url = base_url.rstrip("/") + path_prefix
+                    hips = HttpUrl(hips_base_url + f"/{key}/list")
             results[key] = Dataset(
                 butler_config=self._config.butler_configs.get(key),
                 description=value.description,

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -67,7 +67,7 @@ class HipsLegacyConfig(BaseModel):
     )
 
     dataset: Annotated[
-        str,
+        str | None,
         Field(
             title="Dataset to show under legacy path",
             description=(
@@ -75,7 +75,7 @@ class HipsLegacyConfig(BaseModel):
                 " legacy path. Set to None if legacy paths are not supported."
             ),
         ),
-    ]
+    ] = None
 
     path_prefix: Annotated[
         str,

--- a/noxfile.py
+++ b/noxfile.py
@@ -83,9 +83,7 @@ def lint(session: nox.Session) -> None:
 @session(uv_groups=["dev"])
 def test(session: nox.Session) -> None:
     """Test both the server and the client."""
-    token_path = Path(__file__).parent / "tests" / "data" / "secrets" / "token"
-    token = token_path.read_text().rstrip("\n")
-    session.run("pytest", *session.posargs, env={"REPERTOIRE_TOKEN": token})
+    session.run("pytest", *session.posargs)
 
 
 @session(uv_groups=["dev", "typing"])

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -45,8 +45,8 @@ class Config(RepertoireSettings):
         ),
     )
 
-    token: SecretStr = Field(
-        ...,
+    token: SecretStr | None = Field(
+        None,
         title="Gafaelfawr token",
         description="Gafaelfawr token for HiPS property file retrieval",
         validation_alias=AliasChoices("REPERTOIRE_TOKEN", "token"),

--- a/src/repertoire/dependencies/hips.py
+++ b/src/repertoire/dependencies/hips.py
@@ -129,6 +129,8 @@ class HipsListDependency:
             Raised if an error was encountered retrieving the underlying
             properties file.
         """
+        if not config.token:
+            raise HipsDatasetNotFoundError("HiPS lists not configured")
         if not config.hips or dataset not in config.hips.datasets:
             raise HipsDatasetNotFoundError(f"No HiPS dataset for {dataset}")
         if dataset not in config.available_datasets:

--- a/src/repertoire/dependencies/hips.py
+++ b/src/repertoire/dependencies/hips.py
@@ -95,6 +95,11 @@ class HipsListDependency:
         """
         if not config.hips or not config.hips.legacy:
             raise HipsDatasetNotFoundError("Legacy HiPS list not configured")
+        if not config.hips.legacy.dataset:
+            raise HipsDatasetNotFoundError("Legacy HiPS list not configured")
+        dataset = config.hips.legacy.dataset
+        if dataset not in config.available_datasets:
+            raise HipsDatasetNotFoundError(f"Dataset {dataset} not available")
         return await self.get_list(config.hips.legacy.dataset, config, logger)
 
     async def _build_hips_list(
@@ -126,6 +131,8 @@ class HipsListDependency:
         """
         if not config.hips or dataset not in config.hips.datasets:
             raise HipsDatasetNotFoundError(f"No HiPS dataset for {dataset}")
+        if dataset not in config.available_datasets:
+            raise HipsDatasetNotFoundError(f"Dataset {dataset} not available")
         template = Template(config.hips.source_template)
         context = {"base_hostname": config.base_hostname, "dataset": dataset}
         base_url = template.render(**context)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from jinja2 import Template
 
 from repertoire.config import Config
 from repertoire.dependencies.config import config_dependency
+from repertoire.dependencies.hips import hips_list_dependency
 from repertoire.main import create_app
 from rubin.repertoire import DiscoveryClient
 
@@ -42,6 +43,7 @@ async def app(request: pytest.FixtureRequest) -> AsyncGenerator[FastAPI]:
     """
     config_path = f"config/{request.param}.yaml"
     config_dependency.set_config_path(data_path(config_path))
+    hips_list_dependency.clear_cache()
     app = create_app(secrets_root=data_path("secrets"))
     async with LifespanManager(app):
         yield app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -11,6 +12,7 @@ from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from jinja2 import Template
+from pydantic import SecretStr
 
 from repertoire.config import Config
 from repertoire.dependencies.config import config_dependency
@@ -24,7 +26,9 @@ from .support.hips import register_mock_hips
 
 
 @pytest_asyncio.fixture(params=["phalanx"])
-async def app(request: pytest.FixtureRequest) -> AsyncGenerator[FastAPI]:
+async def app(
+    request: pytest.FixtureRequest, token: str
+) -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -43,6 +47,9 @@ async def app(request: pytest.FixtureRequest) -> AsyncGenerator[FastAPI]:
     """
     config_path = f"config/{request.param}.yaml"
     config_dependency.set_config_path(data_path(config_path))
+    config = config_dependency.config()
+    if config.hips and config.hips.datasets:
+        config.token = SecretStr(token)
     hips_list_dependency.clear_cache()
     app = create_app(secrets_root=data_path("secrets"))
     async with LifespanManager(app):
@@ -69,10 +76,21 @@ def discovery_client(
 
 
 @pytest.fixture(autouse=True)
-def mock_hips(respx_mock: respx.Router) -> None:
+def mock_hips(
+    respx_mock: respx.Router, monkeypatch: pytest.MonkeyPatch, token: str
+) -> None:
+    monkeypatch.setenv("REPERTOIRE_TOKEN", token)
     config = Config.from_file(data_path("config/phalanx.yaml"))
     assert config.hips
+    assert config.token
+    monkeypatch.delenv("REPERTOIRE_TOKEN")
     template = Template(config.hips.source_template)
     for dataset in config.hips.datasets:
         context = {"base_hostname": config.base_hostname, "dataset": dataset}
         register_mock_hips(respx_mock, template.render(**context))
+
+
+@pytest.fixture(scope="session")
+def token() -> str:
+    token_path = Path(__file__).parent / "data" / "secrets" / "token"
+    return token_path.read_text().rstrip("\n")

--- a/tests/data/config/no-hips.yaml
+++ b/tests/data/config/no-hips.yaml
@@ -1,0 +1,14 @@
+# Configuration with HiPS but without the datasets HiPS references.
+
+baseHostname: "data.example.com"
+hips:
+  datasets:
+    dp1:
+      paths:
+        - "deep_coadd/color_ugri"
+        - "deep_coadd/color_gri"
+  legacy:
+    dataset: "dp1"
+    pathPrefix: "/api/hips"
+  pathPrefix: "/api/hips/v2"
+  sourceTemplate: "https://{{base_hostname}}/api/hips/v2/{{dataset}}"

--- a/tests/data/config/no-legacy.yaml
+++ b/tests/data/config/no-legacy.yaml
@@ -18,5 +18,7 @@ hips:
       paths:
         - "deep_coadd/color_ugri"
         - "deep_coadd/color_gri"
+  legacy:
+    pathPrefix: "/api/hips"
   pathPrefix: "/api/hips/v2"
   sourceTemplate: "https://{{base_hostname}}/api/hips/v2/{{dataset}}"

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -58,6 +58,9 @@ datasets:
       Test dataset not listed in availableDatasets.
 hips:
   datasets:
+    dp02:
+      paths:
+        - "deep_coadd/color_ugri"
     dp1:
       paths:
         - "deep_coadd/color_ugri"

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -30,7 +30,8 @@
   "datasets": {
     "dp02": {
       "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml",
-      "description": "Data Preview 0.2 contains the image and catalog products of the Rubin Science Pipelines v23 processing of the DESC Data Challenge 2 simulation, which covered 300 square degrees of the wide-fast-deep LSST survey region over 5 years."
+      "description": "Data Preview 0.2 contains the image and catalog products of the Rubin Science Pipelines v23 processing of the DESC Data Challenge 2 simulation, which covered 300 square degrees of the wide-fast-deep LSST survey region over 5 years.",
+      "hips_list": "https://example.com/api/hips/v2/dp02/list"
     },
     "dp03": {
       "description": "Data Preview 0.3 contains the catalog products of a Solar System Science Collaboration simulation of the results of SSO analysis of the wide-fast-deep data from the LSST dataset."

--- a/tests/handlers/hips_test.py
+++ b/tests/handlers/hips_test.py
@@ -13,8 +13,11 @@ async def test_list(client: AsyncClient) -> None:
     r = await client.get("/api/hips/v2/dp1/list")
     assert r.status_code == 200, f"error body: {r.text}"
     assert r.text == read_test_file("output/hips-dp1-list")
-
     r = await client.get("/api/hips/v2/dp02/list")
+    assert r.status_code == 200, f"error body: {r.text}"
+    r = await client.get("/api/hips/v2/dp03/list")
+    assert r.status_code == 404
+    r = await client.get("/api/hips/v2/unknown/list")
     assert r.status_code == 404
 
 

--- a/tests/handlers/hips_test.py
+++ b/tests/handlers/hips_test.py
@@ -30,3 +30,12 @@ async def test_legacy(client: AsyncClient) -> None:
 async def test_no_legacy(client: AsyncClient) -> None:
     r = await client.get("/api/hips/list")
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("app", ["no-hips"], indirect=True)
+async def test_no_hips(client: AsyncClient) -> None:
+    r = await client.get("/api/hips/list")
+    assert r.status_code == 404
+    r = await client.get("/api/hips/v2/dp1/list")
+    assert r.status_code == 404

--- a/tests/support/hips.py
+++ b/tests/support/hips.py
@@ -38,6 +38,7 @@ class MockHips:
             Returns 200 with the templated properties file.
         """
         config = config_dependency.config()
+        assert config.token
         token = config.token.get_secret_value()
         assert request.headers["Authorization"] == f"Bearer {token}"
         result = self._template.render(path=path)


### PR DESCRIPTION
Ignore the HiPS configuration if the relevant dataset is not in the list of available datasets, for both the legacy and current HiPS list URLs. Allow the legacy HiPS configuration to be partially present but with no dataset set. This configuration flexibility allows simplification of the Phalanx configuration by moving most of the HiPS configuration into `values.yaml` and controlling its use through adjusting `availableDatasets` in `values-<environment>.yaml`.