### PR TITLE
DM-52601: Add aclose method to DiscoveryClient

### DIFF
--- a/changelog.d/20250923_161753_rra_DM_52601.md
+++ b/changelog.d/20250923_161753_rra_DM_52601.md
@@ -1,0 +1,3 @@
+### Backward-incompatible changes
+
+- Add a `DiscoveryClient.aclose` method to cleanly shut down the internal HTTPX async client if one was not passed into the constructor. Users of the Repertoire client who do not use the FastAPI dependency and do not provide an HTTPX client to the `DiscoveryClient` constructor should call this method when they are done using the client.

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -54,6 +54,7 @@ class DiscoveryClient:
         base_url: str | None = None,
     ) -> None:
         self._client = http_client or AsyncClient()
+        self._close_client = http_client is None
         self._discovery_cache: Discovery | None = None
 
         if base_url is not None:
@@ -63,6 +64,14 @@ class DiscoveryClient:
             if not base_url:
                 raise RepertoireUrlError
             self._base_url = base_url.rstrip("/")
+
+    async def aclose(self) -> None:
+        """Close the HTTP client pool, if one wasn't provided.
+
+        This object must not be used after calling this method.
+        """
+        if self._close_client:
+            await self._client.aclose()
 
     async def applications(self) -> list[str]:
         """List applications installed in the local Phalanx environment.

--- a/docs/user-guide/initialization.rst
+++ b/docs/user-guide/initialization.rst
@@ -66,6 +66,8 @@ Most users of Repertoire can create a client with a simple call to the construct
 
 This requires the ``REPERTOIRE_BASE_URL`` environment variable be set to the base URL of the Repertoire service, which is normally arranged via :ref:`Phalanx configuration <client-phalanx>`.
 
+When you are done using the client, call `DiscoveryClient.aclose` to clean up the internal HTTP pool.
+
 Override the base URL
 ---------------------
 
@@ -99,6 +101,9 @@ To use an existing HTTPX ``AsyncClient`` for making requests to Repertoire, pass
 
 This is also the pattern to use if the Repertoire client needs custom HTTPX configuration for whatever reason, such as custom timeouts or special headers.
 That configuration can be added to the HTTPX client before passing it into the `DiscoveryClient` constructor.
+
+If you provide an HTTPX client, you do not need to call `DiscoveryClient.aclose`.
+You are responsible for closing the provided client when appropriate.
 
 Next steps
 ==========

--- a/tests/client/service_test.py
+++ b/tests/client/service_test.py
@@ -77,8 +77,10 @@ async def test_default_client(respx_mock: respx.Router) -> None:
 
     discovery = DiscoveryClient(base_url=base_url)
     assert await discovery.applications() == output["applications"]
+    await discovery.aclose()
 
     # Slashes tend to get accidentally added to the ends of paths, so test
     # that the client is robust.
     discovery = DiscoveryClient(base_url=base_url + "/")
     assert await discovery.applications() == output["applications"]
+    await discovery.aclose()


### PR DESCRIPTION
Add an `aclose` method to shut down the internal HTTPX connection pool if one was not passed to the constructor.