### PR TITLE
DM-52601: Add upper version bounds on client dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "client"
     schedule:
       interval: "weekly"

--- a/changelog.d/20250923_162520_rra_DM_52601.md
+++ b/changelog.d/20250923_162520_rra_DM_52601.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add upper major version bounds on the rubin-repertoire dependencies to ensure a human checks compatibility before allowing updates.

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -19,13 +19,13 @@ classifiers = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi>=0.100",
-    "httpx>=0.28",
-    "jinja2>=3",
-    "pydantic>=2.10",
-    "pydantic-settings>=2.6",
-    "pyyaml>=6",
-    "safir>=4",
+    "fastapi>=0.100,<1",
+    "httpx>=0.28,<1",
+    "jinja2>=3,<4",
+    "pydantic>=2.10,<3",
+    "pydantic-settings>=2.6,<3",
+    "pyyaml>=6,<7",
+    "safir>=4,<14",
 ]
 dynamic = ["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1706,13 +1706,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.100" },
-    { name = "httpx", specifier = ">=0.28" },
-    { name = "jinja2", specifier = ">=3" },
-    { name = "pydantic", specifier = ">=2.10" },
-    { name = "pydantic-settings", specifier = ">=2.6" },
-    { name = "pyyaml", specifier = ">=6" },
-    { name = "safir", specifier = ">=4" },
+    { name = "fastapi", specifier = ">=0.100,<1" },
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "jinja2", specifier = ">=3,<4" },
+    { name = "pydantic", specifier = ">=2.10,<3" },
+    { name = "pydantic-settings", specifier = ">=2.6,<3" },
+    { name = "pyyaml", specifier = ">=6,<7" },
+    { name = "safir", specifier = ">=4,<14" },
 ]
 
 [[package]]


### PR DESCRIPTION
Ensure that a human double-checks compatibility before pulling in new major versions of the rubin-repertoire dependencies.