### PR TITLE
DM-52601: Add support for Sentry

### DIFF
--- a/changelog.d/20250923_163635_rra_DM_52601.md
+++ b/changelog.d/20250923_163635_rra_DM_52601.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add optional support for reporting exceptions to Sentry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic>2",
     "pydantic-settings>=2",
     "rubin-repertoire",
-    "safir>=5",
+    "safir>=13",
     "uvicorn[standard]>=0.34",
 ]
 dynamic = ["version"]

--- a/src/repertoire/main.py
+++ b/src/repertoire/main.py
@@ -11,8 +11,10 @@ from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from safir.fastapi import ClientRequestError, client_request_error_handler
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.sentry import initialize_sentry
 from safir.slack.webhook import SlackRouteErrorHandler
 
+from . import __version__
 from .constants import SECRETS_PATH
 from .dependencies.builder import builder_dependency
 from .dependencies.config import config_dependency
@@ -55,6 +57,9 @@ def create_app(
                 config.slack_webhook, "Repertoire", logger
             )
             logger.debug("Initialized Slack webhook")
+
+    # Initialize Sentry (does nothing if it is not configured).
+    initialize_sentry(release=__version__)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None]:

--- a/uv.lock
+++ b/uv.lock
@@ -1568,7 +1568,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">2" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "rubin-repertoire", editable = "client" },
-    { name = "safir", specifier = ">=5" },
+    { name = "safir", specifier = ">=13" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
 


### PR DESCRIPTION
Call the Safir Sentry initialization function during startup to enable optional support for reporting exceptions to Sentry.