### PR TITLE
DM-52601: Update Docker image, enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.13.5-slim-bookworm AS base-image
+FROM python:3.13.7-slim-trixie AS base-image
 
 # Update system packages.
 COPY scripts/install-base-packages.sh .


### PR DESCRIPTION
Enable dependabot scanning of Docker dependencies and update the server base image to the current Python and Debian versions.