### PR TITLE
DM-52622: Accept and ignore Sentry configuration

### DIFF
--- a/changelog.d/20250924_142554_rra_DM_52622.md
+++ b/changelog.d/20250924_142554_rra_DM_52622.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Accept and ignore a `sentry.enabled` key in the server configuration. This allows Phalanx configuration for Sentry to be added without failing on the unexpected configuration key.

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import AliasChoices, Field, SecretStr
+from pydantic import AliasChoices, BaseModel, Field, SecretStr
 from safir.logging import (
     LogLevel,
     Profile,
@@ -13,6 +13,18 @@ from safir.logging import (
 from rubin.repertoire import RepertoireSettings
 
 __all__ = ["Config"]
+
+
+class SentryConfig(BaseModel):
+    """Sentry configuration for Repertoire.
+
+    This configuration is not used internally, but has to be present in the
+    model so that we can forbid unknown configuration settings. Otherwise,
+    Phalanx wouldn't be able to use the full ``config`` key of the Helm values
+    as the configuration file.
+    """
+
+    enabled: bool = Field(False, title="Whether to send exceptions to Sentry")
 
 
 class Config(RepertoireSettings):
@@ -29,6 +41,8 @@ class Config(RepertoireSettings):
     name: str = Field("Repertoire", title="Name of application")
 
     path_prefix: str = Field("/repertoire", title="URL prefix for application")
+
+    sentry: SentryConfig | None = Field(None, title="Sentry configuration")
 
     slack_alerts: bool = Field(
         False,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,15 @@
+"""Tests for configuration parsing."""
+
+from __future__ import annotations
+
+from repertoire.config import Config
+
+from .support.data import data_path
+
+
+def test_config_sentry() -> None:
+    config = Config.from_file(data_path("config/phalanx.yaml"))
+    assert not config.sentry
+    config = Config.from_file(data_path("config/sentry.yaml"))
+    assert config.sentry
+    assert config.sentry.enabled

--- a/tests/data/config/sentry.yaml
+++ b/tests/data/config/sentry.yaml
@@ -1,0 +1,3 @@
+baseHostname: "data.example.com"
+sentry:
+  enabled: true


### PR DESCRIPTION
Accept and ignore a `sentry.enabled` key in the server configuration. This allows Phalanx configuration for Sentry to be added without failing on the unexpected configuration key.