### PR TITLE
DM-52644: Rename client methods for InfluxDB information

### DIFF
--- a/changelog.d/20250924_165243_rra_DM_52624.md
+++ b/changelog.d/20250924_165243_rra_DM_52624.md
@@ -1,4 +1,4 @@
 ### Backwards-incompatible changes
 
 - Include InfluxDB connection information other than authentication credentials in the main discovery response rather than only a URL to the authenticated route. Put the URL to the authenticated route in a new `credentials_url` key.
-- Return only public connection information, and do not require a token, for `DiscoveryClient.get_influxdb_connection_info`. Add new method `DiscoveryClient.get_influxdb_credentials` that requires a token argument and returns the full connection information including credentials.
+- Add new client method `influxdb_connection_info` that returns only public connection information. Add new client method `influxdb_credentials` that requires a token argument and returns the full connection information including credentials.

--- a/changelog.d/20250925_103628_rra_DM_52644.md
+++ b/changelog.d/20250925_103628_rra_DM_52644.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Remove `DiscoveryClient.get_influxdb_connection_info` in favor of the new `DiscoveryClient.influxdb_connection_info` method.

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -158,14 +158,14 @@ class DiscoveryClient:
         discovery = await self._get_discovery()
         return sorted(discovery.datasets.keys())
 
-    async def get_influxdb_connection_info(
+    async def influxdb_connection_info(
         self, database: str
     ) -> InfluxDatabase | None:
         """Get connection information for an InfluxDB database.
 
         This does not include authentication credentials. Authenticated
-        clients can call `get_influxdb_credentials` instead to get full
-        connection information.
+        clients can call `influxdb_credentials` instead to get full connection
+        information.
 
         Parameters
         ----------
@@ -176,9 +176,8 @@ class DiscoveryClient:
         Returns
         -------
         InfluxDatabase or None
-            Connection information for an InfluxDB database, including
-            credentials, or `None` if this database was not found in this
-            environment.
+            Connection information for an InfluxDB database, or `None` if this
+            database was not found in this environment.
 
         Raises
         ------
@@ -195,7 +194,7 @@ class DiscoveryClient:
         else:
             return None
 
-    async def get_influxdb_credentials(
+    async def influxdb_credentials(
         self, database: str, token: str
     ) -> InfluxDatabaseWithCredentials | None:
         """Get credentials for an InfluxDB database.
@@ -239,7 +238,7 @@ class DiscoveryClient:
         list of str
             Short identifiers (``summit_efd``, for example) of the available
             InfluxDB databases. This string should be passed as the
-            ``database`` argument to `get_influxdb_connection_info`.
+            ``database`` argument to `influxdb_connection_info`.
 
         Raises
         ------

--- a/docs/user-guide/influxdb.rst
+++ b/docs/user-guide/influxdb.rst
@@ -23,12 +23,12 @@ To get a list of InfluxDB databases for which connection information is availabl
    discovery = DiscoveryClient()
    databases = await discovery.influxdb_databases()
 
-The resulting names are short, human-readable names that can be passed as the ``database`` parameter to `DiscoveryClient.get_influxdb_connection_info` or `DiscoveryClient.get_influxdb_credentials` as described below.
+The resulting names are short, human-readable names that can be passed as the ``database`` parameter to `DiscoveryClient.influxdb_connection_info` or `DiscoveryClient.influxdb_credentials` as described below.
 
 Getting connection information
 ==============================
 
-To get the connection information for a specific database, use `DiscoveryClient.get_influxdb_connection_info`:
+To get the connection information for a specific database, use `DiscoveryClient.influxdb_connection_info`:
 
 .. code-block:: python
 
@@ -36,7 +36,7 @@ To get the connection information for a specific database, use `DiscoveryClient.
 
 
    discovery = DiscoveryClient()
-   info = await discovery.get_influxdb_connection_info("some_database")
+   info = await discovery.influxdb_connection_info("some_database")
 
 The resulting object has the following fields:
 
@@ -61,7 +61,7 @@ Inside a service, normally this should be a delegated token received as part of 
 See the `Gafaelfawr documentation on delegated tokens <https://gafaelfawr.lsst.io/user-guide/gafaelfawringress.html#requesting-delegated-tokens>`__ for more information.
 In other environments, this may be a user token created through the token UI, or a notebook token created by Nublado_.
 
-Then, call `DiscoveryClient.get_influxdb_credentials` with the name of the database (possibly obtained via `DiscoveryClient.influxdb_databases`) and that token:
+Then, call `DiscoveryClient.influxdb_credentials` with the name of the database (possibly obtained via `DiscoveryClient.influxdb_databases`) and that token:
 
 .. code-block:: python
 
@@ -70,9 +70,9 @@ Then, call `DiscoveryClient.get_influxdb_credentials` with the name of the datab
 
    discovery = DiscoveryClient()
    token = "..."  # obtained from somewhere else
-   info = await discovery.get_influxdb_credentials("some_database", token)
+   info = await discovery.influxdb_credentials("some_database", token)
 
-The resulting object has the same fields as that retured by `DiscoveryClient.get_influxdb_connection_info`, plus two more:
+The resulting object has the same fields as that retured by `DiscoveryClient.influxdb_connection_info`, plus two more:
 
 ``username``
     Username with which to authenticate.

--- a/tests/client/influxdb_test.py
+++ b/tests/client/influxdb_test.py
@@ -24,12 +24,12 @@ async def test_connection_info(discovery_client: DiscoveryClient) -> None:
     client = discovery_client
 
     for database in ("idfdev_efd", "idfdev_metrics"):
-        output = await client.get_influxdb_connection_info(database)
+        output = await client.influxdb_connection_info(database)
         assert output
         output_json = output.model_dump(mode="json", exclude_none=True)
         assert output_json == read_test_json(f"output/{database}")
 
-    assert await client.get_influxdb_connection_info("invalid") is None
+    assert await client.influxdb_connection_info("invalid") is None
 
 
 @pytest.mark.asyncio
@@ -37,12 +37,12 @@ async def test_credentials(discovery_client: DiscoveryClient) -> None:
     client = discovery_client
 
     for database in ("idfdev_efd", "idfdev_metrics"):
-        output = await client.get_influxdb_credentials(database, "token")
+        output = await client.influxdb_credentials(database, "token")
         assert output
         output_json = output.model_dump(mode="json", exclude_none=True)
         assert output_json == read_test_json(f"output/{database}-creds")
 
-    assert await client.get_influxdb_credentials("invalid", "token") is None
+    assert await client.influxdb_credentials("invalid", "token") is None
 
 
 @pytest.mark.asyncio
@@ -61,7 +61,7 @@ async def test_authentication(respx_mock: respx.Router) -> None:
     respx_mock.get(influxdb_url).mock(side_effect=check_request)
 
     discovery = DiscoveryClient(base_url=f"{TEST_BASE_URL}repertoire")
-    output = await discovery.get_influxdb_credentials("idfdev_efd", token)
+    output = await discovery.influxdb_credentials("idfdev_efd", token)
     assert output
     output_json = output.model_dump(mode="json", exclude_none=True)
     assert output_json == result


### PR DESCRIPTION
Drop the `get_` prefix for consistency with the other APIs and to make code lines a little shorter.