### PR TITLE
DM-52644: Rename url_for_* methods to shorter names

### DIFF
--- a/changelog.d/20250925_104310_rra_DM_52644.md
+++ b/changelog.d/20250925_104310_rra_DM_52644.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Rename client methods `url_for_data_service`, `url_for_internal_service`, and `url_for_ui_service` to `url_for_data`, `url_for_internal`, and `url_for_ui`. These names are a bit more ambiguous, but less likely to make code lines obnoxiously long.

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -147,8 +147,7 @@ class DiscoveryClient:
         list of str
             Short identifiers (``dp1``, for example) of the datasets expected
             to be available in the local Phalanx environment. These are the
-            valid dataset arguments to `butler_config_for` and
-            `url_for_data_service`.
+            valid dataset arguments to `butler_config_for` and `url_for_data`.
 
         Raises
         ------
@@ -248,9 +247,7 @@ class DiscoveryClient:
         discovery = await self._get_discovery()
         return sorted(discovery.influxdb_databases.keys())
 
-    async def url_for_data_service(
-        self, service: str, dataset: str
-    ) -> str | None:
+    async def url_for_data(self, service: str, dataset: str) -> str | None:
         """Return the base API URL for a given data service.
 
         Parameters
@@ -279,7 +276,7 @@ class DiscoveryClient:
         info = datasets.get(dataset)
         return str(info.url) if info else None
 
-    async def url_for_internal_service(self, service: str) -> str | None:
+    async def url_for_internal(self, service: str) -> str | None:
         """Return the base API URL for a given internal service.
 
         Parameters
@@ -302,7 +299,7 @@ class DiscoveryClient:
         info = discovery.services.internal.get(service)
         return str(info.url) if info else None
 
-    async def url_for_ui_service(self, service: str) -> str | None:
+    async def url_for_ui(self, service: str) -> str | None:
         """Return the base URL for a given UI service.
 
         Parameters

--- a/docs/user-guide/datasets.rst
+++ b/docs/user-guide/datasets.rst
@@ -9,7 +9,7 @@ Listing datasets
 To list all of the datasets available in the local environment, call `DiscoveryClient.datasets`.
 The result will be a list of the dataset labels.
 
-These labels are the valid arguments for the dataset parameters to `DiscoveryClient.url_for_data_service` and `DiscoveryClient.butler_config_for` in that environment.
+These labels are the valid arguments for the dataset parameters to `DiscoveryClient.url_for_data` and `DiscoveryClient.butler_config_for` in that environment.
 
 For example:
 
@@ -21,7 +21,7 @@ For example:
    discovery = DiscoveryClient()
    datasets = await discovery.datasets()
    for dataset in datasets:
-       url = await discovery.url_for_data_service("cutout", dataset)
+       url = await discovery.url_for_data("cutout", dataset)
        if url:
            print(f"Cutout API for {dataset}: {url}")
        else:

--- a/docs/user-guide/initialization.rst
+++ b/docs/user-guide/initialization.rst
@@ -46,7 +46,7 @@ Simply import it and include it in the parameters to whatever route needs to do 
        *,
        discovery: Annotated[DiscoveryClient, Depends(discovery_dependency)],
    ) -> SomeModel:
-       cutout_url = discovery.url_for_data_service("cutout-sync", dataset)
+       cutout_url = discovery.url_for_data("cutout-sync", dataset)
        # ...do something with the URL...
 
 This dependency uses `~safir.dependencies.http_client.http_client_dependency` under the hood, so you should insert a call to ``http_client_depnedency.aclose()`` in the cleanup portion of your application's FastAPI lifespan callback.

--- a/docs/user-guide/services.rst
+++ b/docs/user-guide/services.rst
@@ -22,14 +22,14 @@ Service APIs
 
 `DiscoveryClient` provides the following methods to look up services:
 
-`DiscoveryClient.url_for_data_service`
+`DiscoveryClient.url_for_data`
     Takes the name of the service and the name of the dataset and returns the corresponding base URL for that service's REST API, or `None` if that service is not running in the local Phalanx environment or if it doesn't provide that dataset.
     See :doc:`datasets` for information on how to find the dataset names available in the local environment.
 
-`DiscoveryClient.url_for_internal_service`
+`DiscoveryClient.url_for_internal`
     Takes the name of the service and returns the base URL for that service's REST API, or `None` if that service is not running in the local Phalanx environment.
 
-`DiscoveryClient.url_for_ui_service`
+`DiscoveryClient.url_for_ui`
     Takes the name of the service and returns the entry-point URL for the browser-based user interface, or `None` if that service is not running in the local Phalanx environment.
 
 URLs are returned as strings.

--- a/tests/client/service_test.py
+++ b/tests/client/service_test.py
@@ -51,21 +51,21 @@ async def test_url_for(discovery_client: DiscoveryClient) -> None:
 
     for service, info in services["internal"].items():
         url = info["url"]
-        assert await discovery_client.url_for_internal_service(service) == url
-    assert await discovery_client.url_for_internal_service("unknown") is None
+        assert await discovery_client.url_for_internal(service) == url
+    assert await discovery_client.url_for_internal("unknown") is None
 
     for service, info in services["ui"].items():
         url = info["url"]
-        assert await discovery_client.url_for_ui_service(service) == url
-    assert await discovery_client.url_for_ui_service("unknown") is None
+        assert await discovery_client.url_for_ui(service) == url
+    assert await discovery_client.url_for_ui("unknown") is None
 
     client = discovery_client
     for service, mapping in services["data"].items():
         for dataset, info in mapping.items():
-            result = await client.url_for_data_service(service, dataset)
+            result = await client.url_for_data(service, dataset)
             assert result == info["url"]
-        assert await client.url_for_data_service(service, "unknown") is None
-    assert await client.url_for_data_service("unknown", dataset) is None
+        assert await client.url_for_data(service, "unknown") is None
+    assert await client.url_for_data("unknown", dataset) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Rename client methods `url_for_data_service`, `url_for_internal_service`, and `url_for_ui_service` to `url_for_data`, `url_for_internal`, and `url_for_ui`. These names are a bit more ambiguous, but less likely to make code lines obnoxiously long.