### PR TITLE
DM-52644: Add support for API versions

### DIFF
--- a/changelog.d/20250925_115216_rra_DM_52644.md
+++ b/changelog.d/20250925_115216_rra_DM_52644.md
@@ -1,0 +1,5 @@
+### New features
+
+- Add optional API versions to the configuration for data and internal services and include API versions in the discovery information. Each API version, if configured, is a mapping to an object containing the URL and the optional IVOA standardID.
+- Add new client methods `versions_for_data` and `versions_for_internal` that list the available versions for data and internal services.
+- Add an optional `version` argument to client methods `url_for_data` and `url_for_internal` to get the URL of a specific API version instead of the default URL.

--- a/client/src/rubin/repertoire/__init__.py
+++ b/client/src/rubin/repertoire/__init__.py
@@ -3,13 +3,19 @@
 from ._builder import RepertoireBuilder, RepertoireBuilderWithSecrets
 from ._client import DiscoveryClient
 from ._config import (
+    ApiVersionRule,
     BaseRule,
     DataServiceRule,
     DatasetConfig,
+    HipsConfig,
+    HipsDatasetConfig,
+    HipsLegacyConfig,
     InfluxDatabaseConfig,
     InternalServiceRule,
     RepertoireSettings,
+    Rule,
     UiServiceRule,
+    VersionedServiceRule,
 )
 from ._dependencies import DiscoveryDependency, discovery_dependency
 from ._exceptions import (
@@ -21,6 +27,7 @@ from ._exceptions import (
 from ._mock import register_mock_discovery
 from ._models import (
     ApiService,
+    ApiVersion,
     BaseService,
     DataService,
     Dataset,
@@ -34,6 +41,8 @@ from ._models import (
 
 __all__ = [
     "ApiService",
+    "ApiVersion",
+    "ApiVersionRule",
     "BaseRule",
     "BaseService",
     "DataService",
@@ -43,6 +52,9 @@ __all__ = [
     "Discovery",
     "DiscoveryClient",
     "DiscoveryDependency",
+    "HipsConfig",
+    "HipsDatasetConfig",
+    "HipsLegacyConfig",
     "InfluxDatabase",
     "InfluxDatabaseConfig",
     "InfluxDatabaseWithCredentials",
@@ -55,9 +67,11 @@ __all__ = [
     "RepertoireUrlError",
     "RepertoireValidationError",
     "RepertoireWebError",
+    "Rule",
     "Services",
     "UiService",
     "UiServiceRule",
+    "VersionedServiceRule",
     "discovery_dependency",
     "register_mock_discovery",
 ]

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, HttpUrl, PlainSerializer, SecretStr
 
 __all__ = [
     "ApiService",
+    "ApiVersion",
     "BaseService",
     "DataService",
     "Dataset",
@@ -133,6 +134,28 @@ class InfluxDatabaseWithPointer(InfluxDatabase):
     ]
 
 
+class ApiVersion(BaseModel):
+    """One version of a REST API."""
+
+    url: Annotated[
+        HttpUrl,
+        Field(
+            title="Service URL",
+            description="Access URL for that version of the service",
+            examples=["https://example.org/api/cutout/sync"],
+        ),
+    ]
+
+    ivoa_standard_id: Annotated[
+        str | None,
+        Field(
+            title="IVOA standardID",
+            description="IVOA standardID used in service registrations",
+            examples=["ivo://ivoa.net/std/SODA#async-1.0"],
+        ),
+    ] = None
+
+
 class BaseService(BaseModel):
     """Base model for services."""
 
@@ -159,6 +182,17 @@ class ApiService(BaseService):
             examples=["https://example.org/api/cutout/openapi.json"],
         ),
     ] = None
+
+    versions: Annotated[
+        dict[str, ApiVersion],
+        Field(
+            title="API versions",
+            description=(
+                "Discovery information for each API version, if the service"
+                " may have multiple versions"
+            ),
+        ),
+    ] = {}
 
 
 class DataService(ApiService):

--- a/docs/user-guide/services.rst
+++ b/docs/user-guide/services.rst
@@ -20,7 +20,8 @@ Services are divided into three classes:
 Service APIs
 ============
 
-`DiscoveryClient` provides the following methods to look up services:
+`DiscoveryClient` provides the following methods to look up services.
+These APIs do not require authentication.
 
 `DiscoveryClient.url_for_data`
     Takes the name of the service and the name of the dataset and returns the corresponding base URL for that service's REST API, or `None` if that service is not running in the local Phalanx environment or if it doesn't provide that dataset.
@@ -33,7 +34,29 @@ Service APIs
     Takes the name of the service and returns the entry-point URL for the browser-based user interface, or `None` if that service is not running in the local Phalanx environment.
 
 URLs are returned as strings.
-These APIs do not require authentication.
+
+REST API versions
+-----------------
+
+Data and internal services may have multiple REST APIs.
+These can be discovered with the following methods:
+
+`DiscoveryClient.versions_for_data`
+    Takes the name of the service and dataset and returns a list of the available versions in the local Phalanx environment.
+    If the service is not versioned, the list will be empty.
+    If the service is not present in the local environment or doesn't provide that dataset, the return value will be `None`.
+
+`DiscoveryClient.versions_for_internal`
+    Takes the name of the service and returns a list of the available versions in the local Phalanx environment.
+    If the service is not versioned, the list will be empty.
+    If the service is not present in the local environment, the return value will be `None`.
+
+In addition, there is an optional keyword argument, ``version``, to the `~DiscoveryClient.url_for_data` and `~DiscoveryClient.url_for_internal` methods.
+If provided, the method will return the URL for that specific version instead of the default URL.
+The return value will be `None` if the service is not versioned or if that version is not available in the local environment.
+
+In the case of versioned services, the default URL (returned by `~DiscoveryClient.url_for_data` and `~DiscoveryClient.url_for_internal` with no ``version`` argument) will be the base URL of the top-level REST API without any version.
+When ``version`` is provided, the returned URL will be the base URL for that version of the API.
 
 Butler configuration
 ====================

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -94,7 +94,10 @@ rules:
   gafaelfawr:
     - type: "internal"
       name: "gafaelfawr"
-      template: "https://{{base_hostname}}/auth/api/v1"
+      template: "https://{{base_hostname}}/auth/api"
+      versions:
+        v1:
+          template: "https://{{base_hostname}}/auth/api/v1"
       openapi: "https://{{base_hostname}}/auth/openapi.json"
   mobu:
     - type: "internal"
@@ -104,7 +107,10 @@ rules:
   noteburst:
     - type: "internal"
       name: "noteburst"
-      template: "https://{{base_hostname}}/noteburst/v1"
+      template: "https://{{base_hostname}}/noteburst"
+      versions:
+        v1:
+          template: "https://{{base_hostname}}/noteburst/v1"
       openapi: "https://{{base_hostname}}/noteburst/openapi.json"
   nublado:
     - type: "ui"
@@ -144,6 +150,13 @@ rules:
     - type: "data"
       name: "cutout"
       template: "https://{{base_hostname}}/api/cutout"
+      versions:
+        soda-async-1.0:
+          template: "https://{{base_hostname}}/api/cutout/{{dataset}}/jobs"
+          ivoaStandardId: "ivo://ivoa.net/std/SODA#async-1.0"
+        soda-sync-1.0:
+          template: "https://{{base_hostname}}/api/cutout/{{dataset}}/sync"
+          ivoaStandardId: "ivo://ivoa.net/std/SODA#sync-1.0"
       openapi: "https://{{base_hostname}}/api/cutout/openapi.json"
   wobbly:
     - type: "internal"

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -61,58 +61,106 @@
       "cutout": {
         "dp02": {
           "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp02/jobs",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#async-1.0"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp02/sync",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#sync-1.0"
+            }
+          },
           "openapi": "https://data.example.com/api/cutout/openapi.json"
         },
         "dp03": {
           "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp03/jobs",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#async-1.0"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp03/sync",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#sync-1.0"
+            }
+          },
           "openapi": "https://data.example.com/api/cutout/openapi.json"
         },
         "dp1": {
           "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp1/jobs",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#async-1.0"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp1/sync",
+              "ivoa_standard_id": "ivo://ivoa.net/std/SODA#sync-1.0"
+            }
+          },
           "openapi": "https://data.example.com/api/cutout/openapi.json"
         }
       },
       "sia": {
         "dp02": {
           "url": "https://data.example.com/api/sia/dp02",
+          "versions": {},
           "openapi": "https://data.example.com/api/sia/openapi.json"
         },
         "dp1": {
           "url": "https://data.example.com/api/sia/dp1",
+          "versions": {},
           "openapi": "https://data.example.com/api/sia/openapi.json"
         }
       },
       "tap": {
         "dp02": {
-          "url": "https://data.example.com/api/tap"
+          "url": "https://data.example.com/api/tap",
+          "versions": {}
         },
         "dp03": {
-          "url": "https://data.example.com/api/ssotap"
+          "url": "https://data.example.com/api/ssotap",
+          "versions": {}
         },
         "dp1": {
-          "url": "https://data.example.com/api/tap"
+          "url": "https://data.example.com/api/tap",
+          "versions": {}
         }
       }
     },
     "internal": {
       "gafaelfawr": {
-        "url": "https://data.example.com/auth/api/v1",
+        "url": "https://data.example.com/auth/api",
+        "versions": {
+          "v1": {
+            "url": "https://data.example.com/auth/api/v1"
+          }
+        },
         "openapi": "https://data.example.com/auth/openapi.json"
       },
       "mobu": {
         "url": "https://data.example.com/mobu",
+        "versions": {},
         "openapi": "https://data.example.com/mobu/openapi.json"
       },
       "noteburst": {
-        "url": "https://data.example.com/noteburst/v1",
+        "url": "https://data.example.com/noteburst",
+        "versions": {
+          "v1": {
+            "url": "https://data.example.com/noteburst/v1"
+          }
+        },
         "openapi": "https://data.example.com/noteburst/openapi.json"
       },
       "semaphore": {
         "url": "https://data.example.com/semaphore",
+        "versions": {},
         "openapi": "https://data.example.com/semaphore/openapi.json"
       },
       "wobbly": {
         "url": "https://data.example.com/wobbly",
+        "versions": {},
         "openapi": "https://data.example.com/wobbly/openapi.json"
       }
     },


### PR DESCRIPTION
For data and internal services, allow explicit configuration of a mapping of API versions, and include the result in the service discovery output. Each API version currently must have a URL and may have an IVOA standardID.

Add new client APIs `versions_for_data` and `versions_for_internal` to retrieve the list of versions for a given API.

Add new optional `version` parameter to `url_for_data` and `url_for_internal` to request the URL for a specific API version.