### PR TITLE
DM-52657: Minor Repertoire build and documentation fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,6 +159,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Build the package
         run: uv build --no-sources --package rubin-repertoire
@@ -181,6 +183,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Build the package
         run: uv build --no-sources --package rubin-repertoire

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -98,11 +98,13 @@ jobs:
         with:
           fetch-depth: 0 # full history for setuptools_scm
 
-      - name: Test package build of rubin-repertoire
-        uses: lsst-sqre/build-and-publish-to-pypi@v3
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
         with:
-          upload: false
-          working-directory: "client"
+          version: ${{ env.UV_VERSION }}
+
+      - name: Build the package
+        run: uv build --no-sources --package rubin-repertoire
 
       - name: Report status
         if: failure()

--- a/docs/dev/release.rst
+++ b/docs/dev/release.rst
@@ -6,8 +6,7 @@ This page gives an overview of how Repertoire releases are made.
 This information is only useful for maintainers.
 
 Repertoire's releases are largely automated through GitHub Actions (see the `ci.yaml`_ workflow file for details).
-When a semantic version tag is pushed to GitHub, the Repertoire client is `released to PyPI`_ with that version.
-Similarly, documentation is built and pushed for each version (see https://repertoire.lsst.io/v/index.html).
+When a new release is published on GitHub, the Repertoire client is `released to PyPI`_ with that version, a new Docker image is built and uploaded to GitHub, and documentation is built and pushed for the new version (see https://repertoire.lsst.io/v/index.html).
 
 .. _`released to PyPI`: https://pypi.org/project/rubin-repertoire/
 .. _`ci.yaml`: https://github.com/lsst-sqre/repertoire/blob/main/.github/workflows/ci.yaml

--- a/noxfile.py
+++ b/noxfile.py
@@ -102,5 +102,5 @@ def typing(session: nox.Session) -> None:
         "--namespace-packages",
         "--explicit-package-bases",
         "client/src",
-        env={"MYPYPATH": "client/src:client"},
+        env={"MYPYPATH": "client/src"},
     )


### PR DESCRIPTION
- Simplify `MYPYPATH` in the `typing` nox session
- Update the documentation to reflect that Docker images and PyPI packages are pushed on release, not tag
- Pin the uv version in more GitHub Actions jobs
- Update the periodic packaging test to use uv directly