### PR TITLE
DM-52657: Add generation of limited data for Nublado

### DIFF
--- a/changelog.d/20250930_142129_rra_DM_52657.md
+++ b/changelog.d/20250930_142129_rra_DM_52657.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add new client method `build_nublado_dict`, which returns a stripped-down version of service discovery information in dictionary form suitable for JSON encoding. This will be used for service discovery inside [Nublado](https://nublado.lsst.io/) containers. The format is designed to maximize the chance it will continue working with old software stacks.

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from httpx import AsyncClient, HTTPError
 from pydantic import BaseModel, HttpUrl, ValidationError
@@ -92,6 +93,24 @@ class DiscoveryClient:
         """
         discovery = await self._get_discovery()
         return discovery.applications
+
+    async def build_nublado_dict(self) -> dict[str, Any]:
+        """Generate discovery data for Nublado containers.
+
+        User science payloads using a Nublado container consume a
+        pre-generated JSON dump of a restricted and hopefully stable subset of
+        service discovery to allow support of possibly years-old code from
+        older container versions. This method generates a dict containing that
+        stripped-down data set, suitable for subsequent JSON encoding.
+
+        Returns
+        -------
+        dict of dict
+            Restricted subset of discovery information, suitable for JSON
+            encoding.
+        """
+        discovery = await self._get_discovery()
+        return discovery.to_nublado_dict()
 
     async def butler_config_for(self, dataset: str) -> str | None:
         """Return the Butler configuration URL for a given dataset.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -21,6 +21,7 @@ Consumers in other languages, such as JavaScript, can use the Repertoire server 
    datasets
    influxdb
    applications
+   nublado
    testing
 
 .. toctree::

--- a/docs/user-guide/nublado.rst
+++ b/docs/user-guide/nublado.rst
@@ -1,0 +1,57 @@
+:og:description: Learn how to generate stripped-down discovery information for Nublado.
+
+.. py:currentmodule:: rubin.repertoire
+
+#####################################
+Discovery data for Nublado containers
+#####################################
+
+Nublado_ is the JupyterLab component of Phalanx.
+It allows scientists to work inside a container with a possibly older and frozen version of a scientific toolchain so that scientific results are more easily reproducible.
+
+.. _Nublado: https://nublado.lsst.io/
+
+Nubaldo containers may not be able to run the latest versions of client software, but still need service and dataset discovery.
+This need is met by providing, inside the container, a pre-generated JSON file containing current service discovery information.
+The format provides only the information likely to be needed by scientific payloads and omits most of the information in normal service discovery results to minimize the need for backward-incompatible changes.
+
+Generation of this file will be done by the Nublado_ controller.
+The lsst.rsp_ library is responsible for reading this file and answering discovery questions from it.
+
+.. _lsst.rsp: https://github.com/lsst-sqre/lsst-rsp
+
+Data format
+===========
+
+Discovery information is written in JSON format to a file inside the container named :file:`/etc/nublado/discovery/v1.json`.
+The format parallels the current `Discovery` object with the following changes:
+
+#. The ``applications`` key is not present.
+#. Only ``butler_config`` is included as data for each dataset in ``datasets``.
+   Datasets without a Butler configuration will have an empty object value.
+#. Internal and UI services are omitted.
+#. All data for data services is omitted except for ``url`` at the top level and under any ``versions`` dictionary.
+
+Any client reading this data should silently ignore any new fields.
+
+In the future, if some new feature forces a backwards-incompatible revision of this format, Repertoire will retain the ability to generate the v1 version of the data and the new format will use a :file:`v2.json` path.
+This will allow older software to continue to use the v1 JSON file with the features that it supported.
+
+Generating the data
+===================
+
+To generate the data for this JSON file, call `DiscoveryClient.build_nublado_dict`.
+
+The result of this method will be a Python dictionary whose contents have been converted to simple Python data types (`str`, `dict`, etc.).
+This data structure is suitable for JSON serialization.
+
+For example:
+
+.. code-block:: python
+
+   import json
+   from rubin.repertoire import DiscoveryClient
+
+   discovery = DiscoveryClient()
+   nublado_dict = await discovery.build_nublado_dict()
+   nublado_json = json.dumps(nublado_dict, sort_keys=True, indent=2)

--- a/docs/user-guide/testing.rst
+++ b/docs/user-guide/testing.rst
@@ -38,7 +38,7 @@ For example:
    import pytest
    import respx
    from pathlib import Path
-   from rubin.repertoire import register_mock_discovery
+   from rubin.repertoire import Discovery, register_mock_discovery
 
 
    @pytest.fixture(autouse=True)

--- a/tests/client/nublado_test.py
+++ b/tests/client/nublado_test.py
@@ -1,0 +1,15 @@
+"""Tests for generation of stripped-down discovery information for Nublado."""
+
+from __future__ import annotations
+
+import pytest
+
+from rubin.repertoire import DiscoveryClient
+
+from ..support.data import read_test_json
+
+
+@pytest.mark.asyncio
+async def test_nublado(discovery: DiscoveryClient) -> None:
+    output = read_test_json("output/nublado")
+    assert await discovery.build_nublado_dict() == output

--- a/tests/data/output/nublado.json
+++ b/tests/data/output/nublado.json
@@ -1,0 +1,83 @@
+{
+  "datasets": {
+    "dp02": {
+      "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml"
+    },
+    "dp03": {},
+    "dp1": {
+      "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml"
+    }
+  },
+  "influxdb_databases": {
+    "idfdev_efd": {
+      "url": "https://data.example.com/influxdb/",
+      "database": "efd",
+      "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
+      "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_efd"
+    },
+    "idfdev_metrics": {
+      "url": "https://data.example.com/influxdb/",
+      "database": "lsst.square.metrics",
+      "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
+      "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics"
+    }
+  },
+  "services": {
+    "data": {
+      "cutout": {
+        "dp02": {
+          "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp02/jobs"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp02/sync"
+            }
+          }
+        },
+        "dp03": {
+          "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp03/jobs"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp03/sync"
+            }
+          }
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/cutout",
+          "versions": {
+            "soda-async-1.0": {
+              "url": "https://data.example.com/api/cutout/dp1/jobs"
+            },
+            "soda-sync-1.0": {
+              "url": "https://data.example.com/api/cutout/dp1/sync"
+            }
+          }
+        }
+      },
+      "sia": {
+        "dp02": {
+          "url": "https://data.example.com/api/sia/dp02"
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/sia/dp1"
+        }
+      },
+      "tap": {
+        "dp02": {
+          "url": "https://data.example.com/api/tap"
+        },
+        "dp03": {
+          "url": "https://data.example.com/api/ssotap"
+        },
+        "dp1": {
+          "url": "https://data.example.com/api/tap"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add new client method `build_nublado_dict`, which returns a stripped-down version of service discovery information in dictionary form suitable for JSON encoding. This will be used for service discovery inside Nublado containers. The format is designed to maximize the chance it will continue working with old software stacks.