### PR TITLE
DM-52657: Update Dockerfile method for app venv management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Install the application itself.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --no-deps --compile-bytecode .
+    uv sync --frozen --no-default-groups --compile-bytecode --no-editable
 
 FROM base-image AS runtime-image
 
@@ -53,7 +53,7 @@ FROM base-image AS runtime-image
 RUN useradd --create-home appuser
 
 # Copy the virtualenv.
-COPY --from=install-image /app /app
+COPY --from=install-image /app/.venv /app/.venv
 
 # Switch to the non-root user.
 USER appuser
@@ -62,7 +62,6 @@ USER appuser
 EXPOSE 8080
 
 # Make sure we use the virtualenv.
-WORKDIR /app
 ENV PATH="/app/.venv/bin:$PATH"
 
 # Run the application.


### PR DESCRIPTION
Use `uv sync` to install the application instead of `uv pip install` so that it can be installed uneditable, and only copy the actual virtual environment between layers instead of the entire application checkout.