### PR TITLE
DM-52751: Add new docs_url field to dataset information

### DIFF
--- a/changelog.d/20251003_170311_rra_DM_52751.md
+++ b/changelog.d/20251003_170311_rra_DM_52751.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Add new mandatory `docsUrl` field for datasets in the Repertoire configuration, which is copied to the `docs_url` field in the per-dataset discovery information.

--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -119,6 +119,7 @@ class RepertoireBuilder:
             results[key] = Dataset(
                 butler_config=self._config.butler_configs.get(key),
                 description=value.description,
+                docs_url=value.docs_url,
                 hips_list=hips,
             )
         return results

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -41,6 +41,14 @@ class DatasetConfig(BaseModel):
         ),
     ]
 
+    docs_url: Annotated[
+        HttpUrl,
+        Field(
+            title="Documentation URL",
+            description="URL to more detailed documentation about the dataset",
+        ),
+    ]
+
 
 class HipsDatasetConfig(BaseModel):
     """Configuration for a single HiPS dataset."""

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -48,6 +48,15 @@ class Dataset(BaseModel):
         ),
     ]
 
+    docs_url: Annotated[
+        HttpUrl,
+        Field(
+            title="Documentation URL",
+            description="URL to more detailed documentation about the dataset",
+            examples=["https://dp1.example.com/"],
+        ),
+    ]
+
     hips_list: Annotated[
         HttpUrl | None,
         Field(

--- a/tests/data/config/no-legacy.yaml
+++ b/tests/data/config/no-legacy.yaml
@@ -12,6 +12,7 @@ datasets:
       Science Pipelines v29 processing of observations obtained with the LSST
       Commissioning Camera of seven ~1 square degree fields, over seven weeks
       in late 2024.
+    docsUrl: "https://dp1.example.com/"
 hips:
   datasets:
     dp1:

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -42,20 +42,24 @@ datasets:
       Science Pipelines v23 processing of the DESC Data Challenge 2
       simulation, which covered 300 square degrees of the wide-fast-deep LSST
       survey region over 5 years.
+    docsUrl: "https://dp0-2.example.com/"
   dp03:
     description: >-
       Data Preview 0.3 contains the catalog products of a Solar System Science
       Collaboration simulation of the results of SSO analysis of the
       wide-fast-deep data from the LSST dataset.
+    docsUrl: "https://dp0-3.example.com/"
   dp1:
     description: >-
       Data Preview 1 contains image and catalog products from the Rubin
       Science Pipelines v29 processing of observations obtained with the LSST
       Commissioning Camera of seven ~1 square degree fields, over seven weeks
       in late 2024.
+    docsUrl: "https://dp1.example.com/"
   other:
     description: >-
       Test dataset not listed in availableDatasets.
+    docsUrl: "https://unknown.example.com/"
 hips:
   datasets:
     dp02:

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -31,14 +31,17 @@
     "dp02": {
       "butler_config": "https://data.example.com/api/butler/repo/dp02/butler.yaml",
       "description": "Data Preview 0.2 contains the image and catalog products of the Rubin Science Pipelines v23 processing of the DESC Data Challenge 2 simulation, which covered 300 square degrees of the wide-fast-deep LSST survey region over 5 years.",
+      "docs_url": "https://dp0-2.example.com/",
       "hips_list": "https://example.com/api/hips/v2/dp02/list"
     },
     "dp03": {
-      "description": "Data Preview 0.3 contains the catalog products of a Solar System Science Collaboration simulation of the results of SSO analysis of the wide-fast-deep data from the LSST dataset."
+      "description": "Data Preview 0.3 contains the catalog products of a Solar System Science Collaboration simulation of the results of SSO analysis of the wide-fast-deep data from the LSST dataset.",
+      "docs_url": "https://dp0-3.example.com/"
     },
     "dp1": {
       "butler_config": "https://data.example.com/api/butler/repo/dp1/butler.yaml",
       "description": "Data Preview 1 contains image and catalog products from the Rubin Science Pipelines v29 processing of observations obtained with the LSST Commissioning Camera of seven ~1 square degree fields, over seven weeks in late 2024.",
+      "docs_url": "https://dp1.example.com/",
       "hips_list": "https://example.com/api/hips/v2/dp1/list"
     }
   },


### PR DESCRIPTION
Add a new `docsUrl` configuration field and `docs_url` output field for each dataset, containing a pointer to the documentation site for that dataset. This is a new mandatory field.