### PR TITLE
DM-52751: Prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.5.0'></a>
+## 0.5.0 (2025-10-03)
+
+### Backwards-incompatible changes
+
+- Add new mandatory `docsUrl` field for datasets in the Repertoire configuration, which is copied to the `docs_url` field in the per-dataset discovery information.
+
+### New features
+
+- Add new client method `build_nublado_dict`, which returns a stripped-down version of service discovery information in dictionary form suitable for JSON encoding. This will be used for service discovery inside [Nublado](https://nublado.lsst.io/) containers. The format is designed to maximize the chance it will continue working with old software stacks.
+- Add client support for Python 3.12.
+
+### Other changes
+
+- Log a metrics event each time an authenticated user retrieves InfluxDB database credentials.
+
 <a id='changelog-0.4.0'></a>
 ## 0.4.0 (2025-09-25)
 

--- a/changelog.d/20250930_142129_rra_DM_52657.md
+++ b/changelog.d/20250930_142129_rra_DM_52657.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add new client method `build_nublado_dict`, which returns a stripped-down version of service discovery information in dictionary form suitable for JSON encoding. This will be used for service discovery inside [Nublado](https://nublado.lsst.io/) containers. The format is designed to maximize the chance it will continue working with old software stacks.

--- a/changelog.d/20251003_155308_rra_DM_52751.md
+++ b/changelog.d/20251003_155308_rra_DM_52751.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Log a metrics event each time an authenticated user retrieves InfluxDB database credentials.

--- a/changelog.d/20251003_170311_rra_DM_52751.md
+++ b/changelog.d/20251003_170311_rra_DM_52751.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Add new mandatory `docsUrl` field for datasets in the Repertoire configuration, which is copied to the `docs_url` field in the per-dataset discovery information.

--- a/changelog.d/20251003_171408_rra_DM_52751.md
+++ b/changelog.d/20251003_171408_rra_DM_52751.md
@@ -1,3 +1,0 @@
-### New features
-
-- Add client support for Python 3.12.

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -20,7 +20,6 @@
 # Reference for rules: https://docs.astral.sh/ruff/rules/
 exclude = ["docs/**"]
 line-length = 79
-target-version = "py312"
 
 [format]
 docstring-code-format = true

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -17,8 +17,8 @@ uv_version=$(uv export -q --no-hashes --only-group lint \
 for f in .github/workflows/*.yaml; do
     sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
     if ! cmp -s "$f" "${f}.n"; then
-	echo "Updating UV_VERSION to $uv_version in $f"
-	mv "${f}.n" "$f"
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi
@@ -29,7 +29,7 @@ for f in Dockerfile*; do
     sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
     if ! cmp -s "$f" "${f}.n"; then
         echo "Updating uv container version to $uv_version in $f"
-	mv "${f}.n" "$f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi


### PR DESCRIPTION
Collect the change log for the 0.5.0 release. Update the shared Ruff configuration file and `scripts/update-uv-version.sh`.