### PR TITLE
DM-55086: Standardize IVOA standard ID enum names

### DIFF
--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -210,7 +210,7 @@ class RepertoireBuilder:
                     versions={
                         _HIPS_LIST_VERSION: ApiVersion(
                             url=hips_url,
-                            ivoa_standard_id=IvoaStandardId.HIPS_LIST,
+                            ivoa_standard_id=IvoaStandardId.HIPS_LIST_1,
                         )
                     },
                 )

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -242,9 +242,9 @@ class InfluxDatabaseConfig(BaseModel):
 class IvoaStandardId(StrEnum):
     """Known IVOA standard IDs for service capability registrations."""
 
-    DATALINKER = "ivo://ivoa.net/std/DataLink#links-1.1"
+    DATALINK_LINKS_1 = "ivo://ivoa.net/std/DataLink#links-1.1"
     GMS_SEARCH_1 = "ivo://ivoa.net/std/gms#search-1.0"
-    HIPS_LIST = "ivo://ivoa.net/std/hips#hipslist-1.0"
+    HIPS_LIST_1 = "ivo://ivoa.net/std/hips#hipslist-1.0"
     SIA_QUERY_2 = "ivo://ivoa.net/std/SIA#query-2.0"
     SODA_ASYNC_1 = "ivo://ivoa.net/std/SODA#async-1.0"
     SODA_SYNC_1 = "ivo://ivoa.net/std/SODA#sync-1.0"


### PR DESCRIPTION
Use a pattern of standard, API, and major version separated by underscores for all of the `IvoaStandardId` members.