### PR TITLE
DM-55086: Adjust model and validation for registry

### DIFF
--- a/changelog.d/20260529_192117_rra_DM_55086.md
+++ b/changelog.d/20260529_192117_rra_DM_55086.md
@@ -1,0 +1,4 @@
+### Bug fixes
+
+- Ensure a GMS record includes a URL rule with the correct IVOA standards ID.
+- Ensure each data service registers only one URL for a given IVOA standards ID so that the generated IVOA Registry information is predictable and unambiguous.

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -325,10 +325,7 @@ class BaseRegistryEntry(BaseModel):
 
     ivoid: Annotated[
         AnyUrl,
-        Field(
-            title="IVOA ID",
-            description="IVOA identifier of the service.",
-        ),
+        Field(title="IVOA ID", description="IVOA identifier of the service"),
     ]
 
     created: Annotated[
@@ -336,8 +333,8 @@ class BaseRegistryEntry(BaseModel):
         Field(
             title="Creation timestamp",
             description=(
-                "Timestamp of when the service was first published, in ISO"
-                " 8601 format. Set once and never changed."
+                "When the service was first published, set once and never"
+                " changed"
             ),
         ),
     ]
@@ -346,7 +343,7 @@ class BaseRegistryEntry(BaseModel):
         str,
         Field(
             title="Description",
-            description="Long description of the service.",
+            description="Long description of the service",
         ),
     ]
 
@@ -354,7 +351,7 @@ class BaseRegistryEntry(BaseModel):
         str,
         Field(
             title="Title",
-            description="Title of the service.",
+            description="Title of the service",
         ),
     ]
 
@@ -363,7 +360,7 @@ class BaseRegistryEntry(BaseModel):
         Field(
             title="Documentation URL",
             description=(
-                "URL of a human-readable page describing the service."
+                "URL of a human-readable page describing the service"
             ),
         ),
     ] = None
@@ -392,7 +389,7 @@ class TapRegistryEntry(BaseRegistryEntry):
             title="ADQL version",
             description=(
                 "Version of ADQL supported by the TAP service, used in TAP"
-                " registry entries."
+                " registry entries"
             ),
         ),
     ] = "2.1"
@@ -401,13 +398,13 @@ class TapRegistryEntry(BaseRegistryEntry):
         bool,
         Field(
             title="Upload support",
-            description="Whether the TAP service supports table uploads.",
+            description="Whether the TAP service supports table uploads",
         ),
     ] = True
 
 
 type RegistryEntry = Annotated[
-    TapRegistryEntry | SodaRegistryEntry | SiaRegistryEntry | GmsRegistryEntry,
+    GmsRegistryEntry | SiaRegistryEntry | SodaRegistryEntry | TapRegistryEntry,
     Field(discriminator="ivoa_service_type"),
 ]
 
@@ -425,7 +422,7 @@ class MultiRecordRegistryEntry(BaseModel):
             title="Per-dataset registry entries",
             description=(
                 "Mapping of dataset names to the IVOA registry entry for"
-                " that dataset."
+                " that dataset"
             ),
         ),
     ]
@@ -436,23 +433,24 @@ class SiaRegistryEntry(MultiRecordRegistryEntry):
 
     One rule covers multiple datasets. Each dataset's IVOID and metadata are
     stored separately in ``records``. The builder will resolve this into a
-    ``SiaDatasetRegistryEntry`` per dataset when building ``Discovery``.
+    `SiaDatasetRegistryEntry` per dataset when building
+    `~rubin.repertoire.Discovery`.
     """
 
     ivoa_service_type: Literal["sia"]
 
 
 class SiaDatasetRegistryEntry(BaseRegistryEntry):
-    """Resolved per-dataset SIA registry entry, stored on ``DataService``."""
+    """Resolved per-dataset SIA registry entry, stored on `DataService`."""
 
     ivoa_service_type: Literal["sia"]
 
 
 type DatasetRegistryEntry = Annotated[
-    TapRegistryEntry
-    | SodaRegistryEntry
+    GmsRegistryEntry
     | SiaDatasetRegistryEntry
-    | GmsRegistryEntry,
+    | SodaRegistryEntry
+    | TapRegistryEntry,
     Field(discriminator="ivoa_service_type"),
 ]
 
@@ -492,42 +490,85 @@ class DataServiceRule(VersionedServiceRule):
         ),
     ] = None
 
-    @model_validator(mode="after")
-    def _validate_ivoa_versions(self) -> Self:
-        if isinstance(self.ivoa_registry, SodaRegistryEntry):
-            soda_ids = {
-                IvoaStandardId.SODA_SYNC_1,
-                IvoaStandardId.SODA_ASYNC_1,
-            }
-            version_ids = {
-                v.ivoa_standard_id
-                for v in self.versions.values()
-                if v.ivoa_standard_id is not None
-            }
-            missing = soda_ids - version_ids
-            if missing:
-                raise ValueError(
-                    f"SODA rule '{self.name}' missing standard IDs: "
-                    f"{', '.join(sorted(missing))}"
-                )
-            unexpected = version_ids - soda_ids
-            if unexpected:
-                raise ValueError(
-                    f"SODA rule '{self.name}' has unexpected standard IDs: "
-                    f"{', '.join(sorted(unexpected))}"
-                )
-        elif isinstance(self.ivoa_registry, SiaRegistryEntry):
-            version_ids = {
-                v.ivoa_standard_id
-                for v in self.versions.values()
-                if v.ivoa_standard_id is not None
-            }
-            if IvoaStandardId.SIA_QUERY_2 not in version_ids:
-                raise ValueError(
-                    f"SIA rule '{self.name}' must have a version with"
-                    f" standard ID '{IvoaStandardId.SIA_QUERY_2}'"
-                )
+    def ivoa_standard_ids(self) -> set[IvoaStandardId]:
+        """IVOA standard IDs for all provided standardized APIs."""
+        return {
+            v.ivoa_standard_id
+            for v in self.versions.values()
+            if v.ivoa_standard_id is not None
+        }
 
+    def version_for_id(
+        self, ivoa_standard_id: IvoaStandardId
+    ) -> ApiVersionRule | None:
+        """Get the API rule for a specific IVOA standards version.
+
+        Parameters
+        ----------
+        ivoa_standards_version
+            IVOA standards version to search for.
+
+        Returns
+        -------
+        ApiVersionRule or None
+            Corresponding `ApiVersionRule`, or `None` if none was found.
+        """
+        # It is safe to return the first matching entry since the model
+        # validator ensures the service doesn't provide the same IVOA standard
+        # ID on multiple endpoints.
+        for rule in self.versions.values():
+            if rule.ivoa_standard_id == ivoa_standard_id:
+                return rule
+        return None
+
+    @model_validator(mode="after")
+    def _validate_ivoa_standard_ids(self) -> Self:
+        # Ensure there are no duplicate IVOA standard IDs. Generating IVOA
+        # registry information requires a unique rule per standards ID.
+        seen = set()
+        for rule in self.versions.values():
+            if rule.ivoa_standard_id is None:
+                continue
+            if rule.ivoa_standard_id in seen:
+                raise ValueError(
+                    f"Rule '{self.name}' has a duplicate standard ID"
+                    f" '{rule.ivoa_standard_id}'"
+                )
+            seen.add(rule.ivoa_standard_id)
+
+        # If generating IVOA registry information, make sure the SODA and SIA
+        # rules, which require specific IVOA standard IDs in their version
+        # entries, are complete.
+        match self.ivoa_registry:
+            case GmsRegistryEntry():
+                if self.version_for_id(IvoaStandardId.GMS_SEARCH_1) is None:
+                    raise ValueError(
+                        f"GMS rule '{self.name}' must have a version with"
+                        f" standard ID '{IvoaStandardId.GMS_SEARCH_1}'"
+                    )
+            case SiaRegistryEntry():
+                if self.version_for_id(IvoaStandardId.SIA_QUERY_2) is None:
+                    raise ValueError(
+                        f"SIA rule '{self.name}' must have a version with"
+                        f" standard ID '{IvoaStandardId.SIA_QUERY_2}'"
+                    )
+            case SodaRegistryEntry():
+                soda_ids = {
+                    IvoaStandardId.SODA_SYNC_1,
+                    IvoaStandardId.SODA_ASYNC_1,
+                }
+                version_ids = self.ivoa_standard_ids()
+                missing = soda_ids - version_ids
+                if missing:
+                    missing_str = ", ".join(sorted(missing))
+                    raise ValueError(
+                        f"SODA rule '{self.name}' missing standard IDs: "
+                        f"{missing_str}"
+                    )
+            case _:
+                pass
+
+        # Validation succeeded.
         return self
 
 

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -121,6 +121,29 @@ class DataService(ApiService):
         ),
     ] = None
 
+    def version_for_id(
+        self, ivoa_standard_id: IvoaStandardId
+    ) -> ApiVersion | None:
+        """Get the API rule for a specific IVOA standards version.
+
+        Parameters
+        ----------
+        ivoa_standards_version
+            IVOA standards version to search for.
+
+        Returns
+        -------
+        ApiVersionRule or None
+            Corresponding `ApiVersionRule`, or `None` if none was found.
+        """
+        # It is safe to return the first matching entry since the config
+        # validator ensures the service doesn't provide the same IVOA standard
+        # ID on multiple endpoints.
+        for rule in self.versions.values():
+            if rule.ivoa_standard_id == ivoa_standard_id:
+                return rule
+        return None
+
 
 class InternalService(ApiService):
     """An internal API service not tied to a particular dataset."""

--- a/src/repertoire/registry/factory.py
+++ b/src/repertoire/registry/factory.py
@@ -47,6 +47,7 @@ from repertoire.registry.models import (
 )
 from repertoire.registry.store import RecordStore
 from rubin.repertoire import (
+    ApiVersion,
     DataService,
     Discovery,
     GmsRegistryEntry,
@@ -238,7 +239,7 @@ class ResourceRecordFactory:
         )
 
     def _create_gms(
-        self, service: DataService, registry: GmsRegistryEntry
+        self, api_version: ApiVersion, registry: GmsRegistryEntry
     ) -> Service:
         """Create a GMS record for a Group Membership Service.
 
@@ -246,8 +247,8 @@ class ResourceRecordFactory:
 
         Parameters
         ----------
-        service
-            The discovered service corresponding to this registry record.
+        api_version
+            Service discovery information for the GMS IVOA standard ID.
         registry
             The IVOA registry entry containing the IVOID, title, and
             datestamps.
@@ -257,13 +258,7 @@ class ResourceRecordFactory:
         Service
             A Service record for the GMS API.
         """
-        gms_version = next(
-            v
-            for v in service.versions.values()
-            if v.ivoa_standard_id == IvoaStandardId.GMS_SEARCH_1
-        )
-        url = gms_version.url
-
+        interface = self._create_interface(api_version.url)
         return PlainService(
             created=registry.created,
             updated=self._startup_timestamp,
@@ -285,11 +280,7 @@ class ResourceRecordFactory:
                     rights_uri=self._registry_config.rights_uri,
                 )
             ],
-            capability=[
-                GroupMembershipService(
-                    interface=[self._create_interface(url)],
-                )
-            ],
+            capability=[GroupMembershipService(interface=[interface])],
         )
 
     def _create_tap(
@@ -406,22 +397,15 @@ class ResourceRecordFactory:
             A Service record with capabilities for each SODA version.
         """
         capabilities: list[Capability] = []
-        for api_version in service.versions.values():
-            match api_version.ivoa_standard_id:
-                case IvoaStandardId.SODA_SYNC_1:
-                    capabilities.append(
-                        SODASync(
-                            interface=[self._create_interface(api_version.url)]
-                        )
-                    )
-                case IvoaStandardId.SODA_ASYNC_1:
-                    capabilities.append(
-                        SODAAsync(
-                            interface=[self._create_interface(api_version.url)]
-                        )
-                    )
-                case _:
-                    pass
+        async_version = service.version_for_id(IvoaStandardId.SODA_ASYNC_1)
+        if async_version:
+            interface = self._create_interface(async_version.url)
+            capabilities.append(SODAAsync(interface=[interface]))
+        sync_version = service.version_for_id(IvoaStandardId.SODA_SYNC_1)
+        if sync_version:
+            interface = self._create_interface(sync_version.url)
+            capabilities.append(SODASync(interface=[interface]))
+
         return TypedService(
             created=registry.created,
             updated=self._startup_timestamp,
@@ -448,7 +432,7 @@ class ResourceRecordFactory:
 
     def _create_sia(
         self,
-        service: DataService,
+        api_version: ApiVersion,
         registry: SiaDatasetRegistryEntry,
     ) -> Service:
         """Create an SIAv2 service record for a per-collection image access
@@ -456,8 +440,8 @@ class ResourceRecordFactory:
 
         Parameters
         ----------
-        service
-            The discovered service corresponding to this registry record.
+        api_version
+            Service discovery information for the SIAv2 IVOA standard ID.
         registry
             The dataset registry entry for this specific dataset.
 
@@ -466,13 +450,7 @@ class ResourceRecordFactory:
         Service
             A Service record with an SIA capability for this dataset.
         """
-        sia_version = next(
-            v
-            for v in service.versions.values()
-            if v.ivoa_standard_id == IvoaStandardId.SIA_QUERY_2
-        )
-        url = sia_version.url
-
+        interface = self._create_interface(api_version.url)
         return TypedService(
             created=registry.created,
             updated=self._startup_timestamp,
@@ -494,11 +472,7 @@ class ResourceRecordFactory:
                     rights_uri=self._registry_config.rights_uri,
                 )
             ],
-            capability=[
-                SimpleImageAccess(
-                    interface=[self._create_interface(url)],
-                )
-            ],
+            capability=[SimpleImageAccess(interface=[interface])],
         )
 
     def _add_service_record(
@@ -523,13 +497,18 @@ class ResourceRecordFactory:
             )
             return
 
+        kind = None
         match registry:
             case GmsRegistryEntry():
-                records[ivoid] = self._create_gms(service, registry)
-                kind = "GMS"
+                version = service.version_for_id(IvoaStandardId.GMS_SEARCH_1)
+                if version:
+                    records[ivoid] = self._create_gms(version, registry)
+                    kind = "GMS"
             case SiaDatasetRegistryEntry():
-                records[ivoid] = self._create_sia(service, registry)
-                kind = "SIA"
+                version = service.version_for_id(IvoaStandardId.SIA_QUERY_2)
+                if version:
+                    records[ivoid] = self._create_sia(version, registry)
+                    kind = "SIA"
             case SodaRegistryEntry():
                 records[ivoid] = self._create_soda(service, registry)
                 kind = "SODA"
@@ -537,12 +516,13 @@ class ResourceRecordFactory:
                 records[ivoid] = self._create_tap(service, registry)
                 kind = "TAP"
 
-        self._logger.debug(
-            f"Created {kind} record for discovered service",
-            dataset=dataset,
-            service=name,
-            ivoid=ivoid,
-        )
+        if kind:
+            self._logger.debug(
+                f"Created {kind} record for discovered service",
+                dataset=dataset,
+                service=name,
+                ivoid=ivoid,
+            )
 
     def create_all(self) -> RecordStore:
         """Create all VOResource records and return them as a RecordStore.


### PR DESCRIPTION
Standardize field description punctuation. Check that each data service only registers one URL per dataset per IVOA standard ID so that when taking the first matching IVOA standard ID, the corresponding registry information is unambiguous. Drop the check for unknown IVOA standard IDs for SODA; this is adequately handled by using an enum to check the valid standard IDs. Move accessing API versions by IVOA standards ID into a utility method. Ensure a GMS registry entry contains a URL rule with the correct IVOA standards ID.