### PR TITLE
DM-55165: Add local flag to InfluxDB databases

### DIFF
--- a/changelog.d/20260608_165437_rra_DM_55165.md
+++ b/changelog.d/20260608_165437_rra_DM_55165.md
@@ -1,0 +1,4 @@
+### New features
+
+- Add a `local` flag to InfluxDB service discovery information, defaulting to false for backward compatibility. This flag indicates whether the InfluxDB database is located in the same Phalanx environment as the Repertoire server being queried.
+- Add an optional `local` parameter to `DiscoveryClient.influxdb_databases` that, if given, restricts the results to only local or non-local databases.

--- a/client/src/rubin/repertoire/_builder.py
+++ b/client/src/rubin/repertoire/_builder.py
@@ -108,6 +108,7 @@ class RepertoireBuilder:
             url=influxdb.url,
             database=influxdb.database,
             schema_registry=influxdb.schema_registry,
+            local=influxdb.local,
         )
 
     def _build_data_service_from_rule(
@@ -248,6 +249,7 @@ class RepertoireBuilder:
                 database=config.database,
                 schema_registry=config.schema_registry,
                 credentials_url=HttpUrl(creds_url),
+                local=config.local,
             )
         return result
 
@@ -413,6 +415,7 @@ class RepertoireBuilderWithSecrets(RepertoireBuilder):
             username=influxdb.username,
             password=SecretStr(password.rstrip("\n")),
             schema_registry=influxdb.schema_registry,
+            local=influxdb.local,
         )
 
     def list_influxdb_with_credentials(

--- a/client/src/rubin/repertoire/_client.py
+++ b/client/src/rubin/repertoire/_client.py
@@ -243,6 +243,7 @@ class DiscoveryClient:
                 url=info.url,
                 database=info.database,
                 schema_registry=info.schema_registry,
+                local=info.local,
             )
         else:
             return None
@@ -280,11 +281,23 @@ class DiscoveryClient:
         else:
             return None
 
-    async def influxdb_databases(self) -> list[str]:
-        """List InfluxDB databases available in the local Phalanx environment.
+    async def influxdb_databases(
+        self, *, local: bool | None = None
+    ) -> list[str]:
+        """List InfluxDB databases available from this Phalanx environment.
 
-        These may or may not be locally hosted, but the credentials and
-        connection information is available to authenticated users.
+        These may or may not be locally hosted (unless ``local`` is set), but
+        the credentials and connection information is available to
+        authenticated users.
+
+        Parameters
+        ----------
+        local
+            If set to `True`, return only InfluxDB databases hosted in the
+            local Phalanx environment (the one whose service discovery service
+            is being queried). If set to `False`, return only InfluxDB
+            databases that are hosted outside this Phalanx environment. The
+            default, `None`, lists all accessible databases, local or not.
 
         Returns
         -------
@@ -299,7 +312,14 @@ class DiscoveryClient:
             Raised on error fetching discovery information from Repertoire.
         """
         discovery = await self._get_discovery()
-        return sorted(discovery.influxdb_databases.keys())
+        if local is None:
+            return sorted(discovery.influxdb_databases.keys())
+        else:
+            databases = discovery.influxdb_databases.items()
+            if local:
+                return sorted(k for k, v in databases if v.local)
+            else:
+                return sorted(k for k, v in databases if not v.local)
 
     async def url_for_data(
         self, service: str, dataset: str, *, version: str | None = None

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -238,6 +238,14 @@ class InfluxDatabaseConfig(BaseModel):
         ),
     ]
 
+    local: Annotated[
+        bool,
+        Field(
+            title="Is database local",
+            description="Whether the database is local to this environment",
+        ),
+    ] = False
+
 
 class IvoaStandardId(StrEnum):
     """Known IVOA standard IDs for service capability registrations."""

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -268,6 +268,14 @@ class InfluxDatabase(BaseModel):
         ),
     ]
 
+    local: Annotated[
+        bool,
+        Field(
+            title="Is database local",
+            description="Whether the database is local to this environment",
+        ),
+    ] = False
+
 
 class InfluxDatabaseWithCredentials(InfluxDatabase):
     """InfluxDB database connection information with credentials."""

--- a/docs/user-guide/influxdb.rst
+++ b/docs/user-guide/influxdb.rst
@@ -24,6 +24,19 @@ To get a list of InfluxDB databases for which connection information is availabl
 
 The resulting names are short, human-readable names that can be passed as the ``database`` parameter to `DiscoveryClient.influxdb_connection_info` or `DiscoveryClient.influxdb_credentials` as described below.
 
+By defult, all InfluxDB databases accessible from the environment whose discovery service is being queried are returned.
+The list of databases can be restricted to only databases hosted in the same environment as the discovery service, or only databases hosted in remote environments, by passing the ``local`` flag.
+For example:
+
+.. code-block:: python
+   :emphasize-lines: 4-5
+
+   from rubin.repertoire import DiscoveryClient
+
+   discovery = DiscoveryClient()
+   local_databases = await discovery.influxdb_databases(local=True)
+   remote_databases = await discovery.influxdb_databases(local=False)
+
 Getting connection information
 ==============================
 

--- a/tests/client/influxdb_test.py
+++ b/tests/client/influxdb_test.py
@@ -18,6 +18,24 @@ async def test_databases(data: Data, discovery: DiscoveryClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_databases_local(data: Data, discovery: DiscoveryClient) -> None:
+    output = data.read_json("output/phalanx")
+    databases = output["influxdb_databases"].items()
+    expected = [k for k, v in databases if v.get("local")]
+    assert await discovery.influxdb_databases(local=True) == expected
+
+
+@pytest.mark.asyncio
+async def test_databases_remote(
+    data: Data, discovery: DiscoveryClient
+) -> None:
+    output = data.read_json("output/phalanx")
+    databases = output["influxdb_databases"].items()
+    expected = [k for k, v in databases if not v.get("local")]
+    assert await discovery.influxdb_databases(local=False) == expected
+
+
+@pytest.mark.asyncio
 async def test_connection_info(data: Data, discovery: DiscoveryClient) -> None:
     for database in ("idfdev_efd", "idfdev_metrics"):
         output = await discovery.influxdb_connection_info(database)

--- a/tests/data/config/phalanx.yaml
+++ b/tests/data/config/phalanx.yaml
@@ -92,6 +92,7 @@ influxdbDatabases:
     username: "efdreader"
     passwordKey: "idfdev_metrics-password"
     schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+    local: true
 rules:
   argocd:
     - type: "ui"

--- a/tests/data/config/registry.yaml
+++ b/tests/data/config/registry.yaml
@@ -85,12 +85,14 @@ influxdbDatabases:
     username: "efdreader"
     passwordKey: "idfdev_efd-password"
     schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+    local: false
   idfdev_metrics:
     url: "https://data.example.com/influxdb/"
     database: "lsst.square.metrics"
     username: "efdreader"
     passwordKey: "idfdev_metrics-password"
     schemaRegistry: "http://sasquatch-schema-registry.sasquatch:8081"
+    local: true
 ivoaRegistry:
   adminEmail: "registry@example.com"
   authority: "ivo://example.com"

--- a/tests/data/output/idfdev_metrics-creds.json
+++ b/tests/data/output/idfdev_metrics-creds.json
@@ -1,5 +1,6 @@
 {
   "database": "lsst.square.metrics",
+  "local": true,
   "password": "other-password",
   "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
   "url": "https://data.example.com/influxdb/",

--- a/tests/data/output/idfdev_metrics.json
+++ b/tests/data/output/idfdev_metrics.json
@@ -1,5 +1,6 @@
 {
   "database": "lsst.square.metrics",
+  "local": true,
   "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
   "url": "https://data.example.com/influxdb/"
 }

--- a/tests/data/output/nublado.json
+++ b/tests/data/output/nublado.json
@@ -117,12 +117,14 @@
     "idfdev_efd": {
       "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_efd",
       "database": "efd",
+      "local": false,
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "url": "https://data.example.com/influxdb/"
     },
     "idfdev_metrics": {
       "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics",
       "database": "lsst.square.metrics",
+      "local": true,
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "url": "https://data.example.com/influxdb/"
     }

--- a/tests/data/output/phalanx.json
+++ b/tests/data/output/phalanx.json
@@ -163,6 +163,7 @@
     "idfdev_metrics": {
       "credentials_url": "https://example.com/repertoire/discovery/influxdb/idfdev_metrics",
       "database": "lsst.square.metrics",
+      "local": true,
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "url": "https://data.example.com/influxdb/"
     }


### PR DESCRIPTION
Add a `local` flag to InfluxDB service discovery information, defaulting to false for backward compatibility. This flag indicates whether the InfluxDB database is located in the same Phalanx environment as the Repertoire server being queried.

Add an optional `local` parameter to `DiscoveryClient.influxdb_databases` that, if given, restricts the results to only local or non-local databases.