### PR TITLE
DM-55187: Change IVOA Publishing Registry path to /api/registry

### DIFF
--- a/changelog.d/20260609_005344_svoutsinas_DM_55187.md
+++ b/changelog.d/20260609_005344_svoutsinas_DM_55187.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Change IVOA Publishing Registry path to /api/registry

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -86,7 +86,9 @@ class RegistryConfig(BaseModel):
         ),
     )
 
-    path_prefix: str = Field("/discovery", title="URL prefix for the registry")
+    path_prefix: str = Field(
+        "/api", title="URL prefix under which /registry is served"
+    )
 
     rights: str = Field(
         ...,

--- a/src/repertoire/handlers/registry.py
+++ b/src/repertoire/handlers/registry.py
@@ -60,7 +60,7 @@ async def oai_params(request: Request) -> OaiParameters:
 
 
 @registry_router.api_route(
-    "/ivoa",
+    "/registry",
     methods=["GET", "POST"],
     summary="IVOA Publishing Registry",
 )

--- a/src/repertoire/main.py
+++ b/src/repertoire/main.py
@@ -50,7 +50,7 @@ def create_app(
         used by the Helm chart and Docker container.
     """
     path_prefix = "/repertoire"
-    registry_prefix = "/discovery"
+    registry_prefix = "/api"
     if load_config:
         config = config_dependency.config()
         path_prefix = config.path_prefix

--- a/tests/data/output/registry/bad_argument_date_range.xml
+++ b/tests/data/output/registry/bad_argument_date_range.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="badArgument">The 'from' date must not be later than 'until'.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/bad_argument_duplicate.xml
+++ b/tests/data/output/registry/bad_argument_duplicate.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="Identify">https://example.com/discovery/ivoa</request>
+  <request verb="Identify">https://example.com/api/registry</request>
   <error code="badArgument">Repeated query parameters are not permitted.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/bad_argument_forbidden.xml
+++ b/tests/data/output/registry/bad_argument_forbidden.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="Identify" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="Identify" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="badArgument">The 'metadataPrefix' argument is not allowed for Identify.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/bad_argument_invalid_date.xml
+++ b/tests/data/output/registry/bad_argument_invalid_date.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="badArgument">Invalid date format for 'from': 'not-a-date'.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/bad_argument_mixed_granularity.xml
+++ b/tests/data/output/registry/bad_argument_mixed_granularity.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="badArgument">The 'from' and 'until' arguments must use the same date granularity.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/bad_verb.xml
+++ b/tests/data/output/registry/bad_verb.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request>https://example.com/discovery/ivoa</request>
+  <request>https://example.com/api/registry</request>
   <error code="badVerb">Value of the verb argument is not a legal OAI-PMH verb.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/cannot_disseminate_format.xml
+++ b/tests/data/output/registry/cannot_disseminate_format.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListIdentifiers" metadataPrefix="marc21">https://example.com/discovery/ivoa</request>
+  <request verb="ListIdentifiers" metadataPrefix="marc21">https://example.com/api/registry</request>
   <error code="cannotDisseminateFormat">Metadata format 'marc21' is not supported. Supported formats: ivo_vor, oai_dc.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/get_record.xml
+++ b/tests/data/output/registry/get_record.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="GetRecord" identifier="ivo://example.com/tap" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="GetRecord" identifier="ivo://example.com/tap" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <GetRecord>
     <record>
       <header>

--- a/tests/data/output/registry/get_record_missing_id.xml
+++ b/tests/data/output/registry/get_record_missing_id.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="GetRecord" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="GetRecord" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="badArgument">The 'identifier' argument is required for GetRecord.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/get_record_wrong_prefix.xml
+++ b/tests/data/output/registry/get_record_wrong_prefix.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="GetRecord" identifier="ivo://example.com/tap" metadataPrefix="not_ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="GetRecord" identifier="ivo://example.com/tap" metadataPrefix="not_ivo_vor">https://example.com/api/registry</request>
   <error code="cannotDisseminateFormat">Metadata format 'not_ivo_vor' is not supported. Supported formats: ivo_vor, oai_dc.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/id_does_not_exist.xml
+++ b/tests/data/output/registry/id_does_not_exist.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="GetRecord" identifier="ivo://example.com/nonexistent" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="GetRecord" identifier="ivo://example.com/nonexistent" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="idDoesNotExist">No record found with identifier 'ivo://example.com/nonexistent'.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/identify.xml
+++ b/tests/data/output/registry/identify.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="Identify">https://example.com/discovery/ivoa</request>
+  <request verb="Identify">https://example.com/api/registry</request>
   <Identify>
     <repositoryName>Example Publishing Registry</repositoryName>
-    <baseURL>https://example.com/discovery/ivoa</baseURL>
+    <baseURL>https://example.com/api/registry</baseURL>
     <protocolVersion>2.0</protocolVersion>
     <adminEmail>registry@example.com</adminEmail>
     <earliestDatestamp>2026-04-16T00:00:00Z</earliestDatestamp>
@@ -31,7 +31,7 @@
         </content>
         <capability standardID="ivo://ivoa.net/std/Registry" xsi:type="vg:Harvest">
           <interface role="std" xsi:type="vg:OAIHTTP">
-            <accessURL use="base">https://example.com/discovery/ivoa</accessURL>
+            <accessURL use="base">https://example.com/api/registry</accessURL>
           </interface>
         </capability>
         <full>false</full>

--- a/tests/data/output/registry/list_identifiers.xml
+++ b/tests/data/output/registry/list_identifiers.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListIdentifiers" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListIdentifiers" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <ListIdentifiers>
     <header>
       <identifier>ivo://example.com/registry</identifier>

--- a/tests/data/output/registry/list_metadata_formats.xml
+++ b/tests/data/output/registry/list_metadata_formats.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListMetadataFormats">https://example.com/discovery/ivoa</request>
+  <request verb="ListMetadataFormats">https://example.com/api/registry</request>
   <ListMetadataFormats>
     <metadataFormat>
       <metadataPrefix>ivo_vor</metadataPrefix>

--- a/tests/data/output/registry/list_metadata_formats_bad_id.xml
+++ b/tests/data/output/registry/list_metadata_formats_bad_id.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListMetadataFormats" identifier="ivo://example.com/nonexistent">https://example.com/discovery/ivoa</request>
+  <request verb="ListMetadataFormats" identifier="ivo://example.com/nonexistent">https://example.com/api/registry</request>
   <error code="idDoesNotExist">No record found with identifier 'ivo://example.com/nonexistent'.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/list_no_records.xml
+++ b/tests/data/output/registry/list_no_records.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <error code="noRecordsMatch">The combination of arguments results in an empty list.</error>
 </OAI-PMH>

--- a/tests/data/output/registry/list_records.xml
+++ b/tests/data/output/registry/list_records.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/discovery/ivoa</request>
+  <request verb="ListRecords" metadataPrefix="ivo_vor">https://example.com/api/registry</request>
   <ListRecords>
     <record>
       <header>
@@ -30,7 +30,7 @@
           </content>
           <capability standardID="ivo://ivoa.net/std/Registry" xsi:type="vg:Harvest">
             <interface role="std" xsi:type="vg:OAIHTTP">
-              <accessURL use="base">https://example.com/discovery/ivoa</accessURL>
+              <accessURL use="base">https://example.com/api/registry</accessURL>
             </interface>
           </capability>
           <full>false</full>

--- a/tests/data/output/registry/list_sets.xml
+++ b/tests/data/output/registry/list_sets.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
   <responseDate>1970-01-01T00:00:00Z</responseDate>
-  <request verb="ListSets">https://example.com/discovery/ivoa</request>
+  <request verb="ListSets">https://example.com/api/registry</request>
   <ListSets>
     <set>
       <setSpec>ivo_managed</setSpec>

--- a/tests/handlers/registry_test.py
+++ b/tests/handlers/registry_test.py
@@ -28,7 +28,7 @@ def normalize_oai_xml(xml: str) -> str:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_identify(data: Data, client: AsyncClient) -> None:
-    r = await client.get("/discovery/ivoa?verb=Identify")
+    r = await client.get("/api/registry?verb=Identify")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text), "output/registry/identify.xml"
@@ -38,7 +38,7 @@ async def test_identify(data: Data, client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_list_metadata_formats(data: Data, client: AsyncClient) -> None:
-    r = await client.get("/discovery/ivoa?verb=ListMetadataFormats")
+    r = await client.get("/api/registry?verb=ListMetadataFormats")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text), "output/registry/list_metadata_formats.xml"
@@ -48,7 +48,7 @@ async def test_list_metadata_formats(data: Data, client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_list_sets(data: Data, client: AsyncClient) -> None:
-    r = await client.get("/discovery/ivoa?verb=ListSets")
+    r = await client.get("/api/registry?verb=ListSets")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text), "output/registry/list_sets.xml"
@@ -59,7 +59,7 @@ async def test_list_sets(data: Data, client: AsyncClient) -> None:
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_list_identifiers(data: Data, client: AsyncClient) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListIdentifiers&metadataPrefix=ivo_vor"
+        "/api/registry?verb=ListIdentifiers&metadataPrefix=ivo_vor"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -72,8 +72,8 @@ async def test_list_identifiers(data: Data, client: AsyncClient) -> None:
 @pytest.mark.parametrize(
     "url",
     [
-        "/discovery/ivoa?verb=NotAVerb",
-        "/discovery/ivoa",
+        "/api/registry?verb=NotAVerb",
+        "/api/registry",
     ],
 )
 async def test_bad_verb(url: str, data: Data, client: AsyncClient) -> None:
@@ -90,7 +90,7 @@ async def test_cannot_disseminate_format(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListIdentifiers&metadataPrefix=marc21"
+        "/api/registry?verb=ListIdentifiers&metadataPrefix=marc21"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -103,7 +103,7 @@ async def test_cannot_disseminate_format(
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_id_does_not_exist(data: Data, client: AsyncClient) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=GetRecord&metadataPrefix=ivo_vor&identifier=ivo://example.com/nonexistent"
+        "/api/registry?verb=GetRecord&metadataPrefix=ivo_vor&identifier=ivo://example.com/nonexistent"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -115,7 +115,7 @@ async def test_id_does_not_exist(data: Data, client: AsyncClient) -> None:
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_list_records(data: Data, client: AsyncClient) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor"
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -127,7 +127,7 @@ async def test_list_records(data: Data, client: AsyncClient) -> None:
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_get_record(data: Data, client: AsyncClient) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=GetRecord&metadataPrefix=ivo_vor&identifier=ivo://example.com/tap"
+        "/api/registry?verb=GetRecord&metadataPrefix=ivo_vor&identifier=ivo://example.com/tap"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -138,9 +138,7 @@ async def test_get_record(data: Data, client: AsyncClient) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_get_record_missing_id(data: Data, client: AsyncClient) -> None:
-    r = await client.get(
-        "/discovery/ivoa?verb=GetRecord&metadataPrefix=ivo_vor"
-    )
+    r = await client.get("/api/registry?verb=GetRecord&metadataPrefix=ivo_vor")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text), "output/registry/get_record_missing_id.xml"
@@ -153,7 +151,7 @@ async def test_get_record_wrong_prefix(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=GetRecord&metadataPrefix=not_ivo_vor&identifier"
+        "/api/registry?verb=GetRecord&metadataPrefix=not_ivo_vor&identifier"
         "=ivo://example.com/tap"
     )
     assert r.status_code == 200
@@ -168,10 +166,10 @@ async def test_get_record_wrong_prefix(
 @pytest.mark.parametrize(
     "url",
     [
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01",
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01T00:00:00Z",
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&until=2026-12-12",
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&until=2026-12-12T00:00:00Z",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01T00:00:00Z",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&until=2026-12-12",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&until=2026-12-12T00:00:00Z",
     ],
 )
 async def test_list_records_date_filter(
@@ -189,8 +187,8 @@ async def test_list_records_date_filter(
 @pytest.mark.parametrize(
     "url",
     [
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&from=2026-12-12",
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01&until=1961-01-01",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&from=2026-12-12",
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&from=1960-01-01&until=1961-01-01",
     ],
 )
 async def test_list_records_no_results(
@@ -209,7 +207,7 @@ async def test_list_metadata_formats_bad_identifier(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListMetadataFormats"
+        "/api/registry?verb=ListMetadataFormats"
         "&identifier=ivo://example.com/nonexistent"
     )
     assert r.status_code == 200
@@ -224,7 +222,7 @@ async def test_list_metadata_formats_bad_identifier(
 async def test_bad_argument_duplicate_params(
     data: Data, client: AsyncClient
 ) -> None:
-    r = await client.get("/discovery/ivoa?verb=Identify&verb=Identify")
+    r = await client.get("/api/registry?verb=Identify&verb=Identify")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text),
@@ -235,9 +233,7 @@ async def test_bad_argument_duplicate_params(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_bad_argument_forbidden(data: Data, client: AsyncClient) -> None:
-    r = await client.get(
-        "/discovery/ivoa?verb=Identify&metadataPrefix=ivo_vor"
-    )
+    r = await client.get("/api/registry?verb=Identify&metadataPrefix=ivo_vor")
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text),
@@ -251,7 +247,7 @@ async def test_bad_argument_invalid_date(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor&from=not-a-date"
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor&from=not-a-date"
     )
     assert r.status_code == 200
     data.assert_text_matches(
@@ -266,7 +262,7 @@ async def test_bad_argument_from_after_until(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor"
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor"
         "&from=2026-01-01&until=2025-01-01"
     )
     assert r.status_code == 200
@@ -282,7 +278,7 @@ async def test_bad_argument_mixed_granularity(
     data: Data, client: AsyncClient
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListRecords&metadataPrefix=ivo_vor"
+        "/api/registry?verb=ListRecords&metadataPrefix=ivo_vor"
         "&from=2025-01-01&until=2025-01-01T00:00:00Z"
     )
     assert r.status_code == 200
@@ -295,7 +291,7 @@ async def test_bad_argument_mixed_granularity(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("app", ["registry"], indirect=True)
 async def test_post_identify(data: Data, client: AsyncClient) -> None:
-    r = await client.post("/discovery/ivoa", data={"verb": "Identify"})
+    r = await client.post("/api/registry", data={"verb": "Identify"})
     assert r.status_code == 200
     data.assert_text_matches(
         normalize_oai_xml(r.text), "output/registry/identify.xml"
@@ -308,7 +304,7 @@ async def test_list_identifiers_excludes_unregistered_services(
     client: AsyncClient,
 ) -> None:
     r = await client.get(
-        "/discovery/ivoa?verb=ListIdentifiers&metadataPrefix=ivo_vor"
+        "/api/registry?verb=ListIdentifiers&metadataPrefix=ivo_vor"
     )
     assert r.status_code == 200
     assert "ssotap" not in r.text


### PR DESCRIPTION
Change OAI api route to /registry instead of /ivoa
Use /api as the default registry prefix instead of /discovery