### PR TITLE
DM-55165: Add internal services to Nublado discovery

### DIFF
--- a/changelog.d/20260611_083147_rra_DM_55165.md
+++ b/changelog.d/20260611_083147_rra_DM_55165.md
@@ -1,0 +1,3 @@
+### New features
+
+- Include internal services in the Nublado service discovery information. Users should not use this portion of service discovery, but making it available to notebooks aids in writing test notebooks for internal services such as [Semaphore](https://semaphore.lsst.io/) and [Gafaelfawr](https://gafaelfawr.lsst.io/).

--- a/client/src/rubin/repertoire/_models.py
+++ b/client/src/rubin/repertoire/_models.py
@@ -365,6 +365,22 @@ class Services(BaseModel):
         ),
     ] = {}
 
+    def to_nublado_dict(self) -> dict[str, dict[str, Any]]:
+        """Convert to the reduced format used inside Nublado containers.
+
+        Returns
+        -------
+        dict of dict
+            Restricted subset of dataset discovery, suitable for JSON
+            encoding.
+        """
+        result: dict[str, Any] = {}
+        if self.internal:
+            result["internal"] = {}
+            for service, info in self.internal.items():
+                result["internal"][service] = info.to_nublado_dict()
+        return result
+
 
 class Discovery(BaseModel):
     """Service discovery information."""
@@ -447,5 +463,6 @@ class Discovery(BaseModel):
                 k: v.model_dump(mode="json")
                 for k, v in self.influxdb_databases.items()
             },
+            "services": self.services.to_nublado_dict(),
         }
         return {k: v for k, v in results.items() if v}

--- a/tests/data/output/nublado.json
+++ b/tests/data/output/nublado.json
@@ -128,5 +128,34 @@
       "schema_registry": "http://sasquatch-schema-registry.sasquatch:8081/",
       "url": "https://data.example.com/influxdb/"
     }
+  },
+  "services": {
+    "internal": {
+      "gafaelfawr": {
+        "url": "https://data.example.com/auth/api",
+        "versions": {
+          "v1": {
+            "url": "https://data.example.com/auth/api/v1"
+          }
+        }
+      },
+      "mobu": {
+        "url": "https://data.example.com/mobu"
+      },
+      "noteburst": {
+        "url": "https://data.example.com/noteburst",
+        "versions": {
+          "v1": {
+            "url": "https://data.example.com/noteburst/v1"
+          }
+        }
+      },
+      "semaphore": {
+        "url": "https://data.example.com/semaphore"
+      },
+      "wobbly": {
+        "url": "https://data.example.com/wobbly"
+      }
+    }
   }
 }


### PR DESCRIPTION
Include internal services in the Nublado service discovery information. Users should not use this portion of service discovery, but making it available to notebooks aids in writing test notebooks for internal services such as Semaphore and Gafaelfawr.