### PR TITLE
DM-55165: Replace pathPrefix with path for the registry

### DIFF
--- a/changelog.d/20260609_005344_svoutsinas_DM_55187.md
+++ b/changelog.d/20260609_005344_svoutsinas_DM_55187.md
@@ -1,5 +1,5 @@
 <!-- Delete the sections that don't apply -->
 
-### Other changes
+### Backwards-incompatible changes
 
-- Change IVOA Publishing Registry path to /api/registry
+- Replace the Helm configuration parameter `ivoaRegistry.pathPrefix` with `ivoaRegistry.path`, which specifies the full path to the URL at which the registry is served (if enabled). This allows full control of the path in Phalanx configuration, instead of having to change the last component in the Repertoire source.

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -86,8 +86,8 @@ class RegistryConfig(BaseModel):
         ),
     )
 
-    path_prefix: str = Field(
-        "/api", title="URL prefix under which /registry is served"
+    path: str = Field(
+        "/api/registry", title="URL at which to serve the registry"
     )
 
     rights: str = Field(

--- a/src/repertoire/handlers/registry.py
+++ b/src/repertoire/handlers/registry.py
@@ -60,7 +60,7 @@ async def oai_params(request: Request) -> OaiParameters:
 
 
 @registry_router.api_route(
-    "/registry",
+    "",
     methods=["GET", "POST"],
     summary="IVOA Publishing Registry",
 )

--- a/src/repertoire/main.py
+++ b/src/repertoire/main.py
@@ -49,13 +49,13 @@ def create_app(
         Overrides the default secrets root of :file:`/etc/repertoire/secrets`
         used by the Helm chart and Docker container.
     """
-    path_prefix = "/repertoire"
-    registry_prefix = "/api"
     if load_config:
         config = config_dependency.config()
         path_prefix = config.path_prefix
         if config.ivoa_registry:
-            registry_prefix = config.ivoa_registry.path_prefix
+            registry_path = config.ivoa_registry.path
+        else:
+            registry_path = "/api/registry"
 
         # Configure Slack alerts.
         if config.slack_alerts and config.slack_webhook:
@@ -64,6 +64,9 @@ def create_app(
                 config.slack_webhook, "Repertoire", logger
             )
             logger.debug("Initialized Slack webhook")
+    else:
+        path_prefix = "/repertoire"
+        registry_path = "/api/registry"
 
     # Initialize Sentry (does nothing if it is not configured).
     initialize_sentry(release=__version__)
@@ -99,7 +102,7 @@ def create_app(
         if config.hips.legacy:
             legacy_path_prefix = config.hips.legacy.path_prefix
             app.include_router(hips_legacy_router, prefix=legacy_path_prefix)
-    app.include_router(registry_router, prefix=registry_prefix)
+    app.include_router(registry_router, prefix=registry_path)
 
     # Add middleware.
     app.add_middleware(XForwardedMiddleware)


### PR DESCRIPTION
Replace the Helm configuration parameter `ivoaRegistry.pathPrefix` with `ivoaRegistry.path`, which specifies the full path to the URL at which the registry is served (if enabled). This allows full control of the path in Phalanx configuration, instead of having to change the last component in the Repertoire source.