### PR TITLE
DM-55229: Fix __all__ for tests.support.constants

### DIFF
--- a/tests/support/constants.py
+++ b/tests/support/constants.py
@@ -1,6 +1,6 @@
 """Constants for tests."""
 
-__all__ = ["TEST_BASE_URL"]
+__all__ = ["POSTGRES_IMAGE", "TEST_BASE_URL"]
 
 POSTGRES_IMAGE = "postgres:18"
 """PostgreSQL Docker image to use for testing."""


### PR DESCRIPTION
Properly export all of the symbols this test module provides.