### PR TITLE
DM-55484: Add vs:DataResource records and fix SODA type to vs:DataService

### DIFF
--- a/changelog.d/20260713_221209_steliosvoutsinas_DM_55484.md
+++ b/changelog.d/20260713_221209_steliosvoutsinas_DM_55484.md
@@ -1,0 +1,9 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Add vs:DataResource records
+
+### Bug fixes
+
+- Fix SODA type to vs:DataService

--- a/client/src/rubin/repertoire/_config.py
+++ b/client/src/rubin/repertoire/_config.py
@@ -47,29 +47,6 @@ __all__ = [
 ]
 
 
-class DatasetConfig(BaseModel):
-    """Metadata for an available dataset."""
-
-    model_config = ConfigDict(
-        alias_generator=to_camel, extra="forbid", validate_by_name=True
-    )
-
-    description: Annotated[
-        str,
-        Field(
-            title="Description", description="Long description of the dataset"
-        ),
-    ]
-
-    docs_url: Annotated[
-        HttpUrl | None,
-        Field(
-            title="Documentation URL",
-            description="URL to more detailed documentation about the dataset",
-        ),
-    ] = None
-
-
 class HipsDatasetConfig(BaseModel):
     """Configuration for a single HiPS dataset."""
 
@@ -431,6 +408,41 @@ class BaseRegistryEntry(BaseModel):
             description="Instrument names associated with this record.",
         ),
     ] = []
+
+
+class DatasetConfig(BaseModel):
+    """Metadata for an available dataset."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="forbid", validate_by_name=True
+    )
+
+    description: Annotated[
+        str,
+        Field(
+            title="Description", description="Long description of the dataset"
+        ),
+    ]
+
+    docs_url: Annotated[
+        HttpUrl | None,
+        Field(
+            title="Documentation URL",
+            description="URL to more detailed documentation about the dataset",
+        ),
+    ] = None
+
+    ivoa_registry: Annotated[
+        BaseRegistryEntry | None,
+        Field(
+            title="IVOA registry entry",
+            description=(
+                "If set, publishes a ``vs:DataResource`` record for this"
+                " dataset, serving as the resolvable registry target for"
+                " Butler datasets and HiPS survey IVOIDs."
+            ),
+        ),
+    ] = None
 
 
 class GmsRegistryEntry(BaseRegistryEntry):

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -22,7 +22,7 @@ from safir.logging import (
 )
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 
-from rubin.repertoire import RepertoireSettings
+from rubin.repertoire import BaseRegistryEntry, RepertoireSettings
 
 __all__ = ["Config"]
 
@@ -130,6 +130,17 @@ class RegistryConfig(BaseModel):
             "Facility names applied to published service records that do not"
             " specify their own facility. Per-record facilities overrides this"
             " default entirely (not additive)."
+        ),
+    )
+
+    dataset_records: dict[str, BaseRegistryEntry] = Field(
+        {},
+        title="Dataset collection records",
+        description=(
+            "Mapping of dataset names to ``vs:DataResource`` registry"
+            " records. Each entry is published as a release collection"
+            " record serving as the resolvable target for object-specific"
+            " IVOIDs (Butler datasets, HiPS etc)."
         ),
     )
 

--- a/src/repertoire/config.py
+++ b/src/repertoire/config.py
@@ -22,7 +22,7 @@ from safir.logging import (
 )
 from safir.metrics import MetricsConfiguration, metrics_configuration_factory
 
-from rubin.repertoire import BaseRegistryEntry, RepertoireSettings
+from rubin.repertoire import RepertoireSettings
 
 __all__ = ["Config"]
 
@@ -130,17 +130,6 @@ class RegistryConfig(BaseModel):
             "Facility names applied to published service records that do not"
             " specify their own facility. Per-record facilities overrides this"
             " default entirely (not additive)."
-        ),
-    )
-
-    dataset_records: dict[str, BaseRegistryEntry] = Field(
-        {},
-        title="Dataset collection records",
-        description=(
-            "Mapping of dataset names to ``vs:DataResource`` registry"
-            " records. Each entry is published as a release collection"
-            " record serving as the resolvable target for object-specific"
-            " IVOIDs (Butler datasets, HiPS etc)."
         ),
     )
 

--- a/src/repertoire/dependencies/registry.py
+++ b/src/repertoire/dependencies/registry.py
@@ -78,6 +78,7 @@ class OaiHandlerDependency:
                 startup_timestamp=self._startup_timestamp,
                 oai_url=oai_url,
                 logger=logger,
+                datasets=config.datasets,
             ).create_all()
 
             # Initialize the handler for the first request and cache it.

--- a/src/repertoire/registry/factory.py
+++ b/src/repertoire/registry/factory.py
@@ -51,6 +51,7 @@ from rubin.repertoire import (
     ApiVersion,
     BaseRegistryEntry,
     DataService,
+    DatasetConfig,
     Discovery,
     GmsRegistryEntry,
     IvoaContentLevel,
@@ -94,10 +95,12 @@ class ResourceRecordFactory:
         startup_timestamp: datetime,
         oai_url: str,
         logger: BoundLogger,
+        datasets: dict[str, DatasetConfig] | None = None,
     ) -> None:
         self._registry_config = registry_config
         self._discovery = discovery
         self._startup_timestamp = startup_timestamp
+        self._datasets: dict[str, DatasetConfig] = datasets or {}
         self._oai_url: AnyUrl = TypeAdapter(AnyUrl).validate_python(oai_url)
         self._curation = self._create_curation()
         self._logger = logger
@@ -768,9 +771,12 @@ class ResourceRecordFactory:
                         records, dataset, service, service.ivoa_registry
                     )
 
-        for entry in self._registry_config.dataset_records.values():
-            ivoid = str(entry.ivoid)
-            if ivoid not in records:
-                records[ivoid] = self._create_data_resource(entry)
+        for dataset_config in self._datasets.values():
+            if dataset_config.ivoa_registry is not None:
+                ivoid = str(dataset_config.ivoa_registry.ivoid)
+                if ivoid not in records:
+                    records[ivoid] = self._create_data_resource(
+                        dataset_config.ivoa_registry
+                    )
 
         return RecordStore(records=records)

--- a/src/repertoire/registry/factory.py
+++ b/src/repertoire/registry/factory.py
@@ -32,6 +32,7 @@ from repertoire.config import RegistryConfig
 from repertoire.registry.constants import TAP_OUTPUT_FORMAT_MIME, TAP_UPLOAD_ID
 from repertoire.registry.models import (
     CatalogResource,
+    DataResource,
     GroupMembershipService,
     PlainService,
     RegistryOrganisation,
@@ -39,6 +40,7 @@ from repertoire.registry.models import (
     SODAAsync,
     SODASync,
     TapAux,
+    TypedDataService,
     TypedService,
     VOSIAvailability,
     VOSICapabilities,
@@ -47,6 +49,7 @@ from repertoire.registry.models import (
 from repertoire.registry.store import RecordStore
 from rubin.repertoire import (
     ApiVersion,
+    BaseRegistryEntry,
     DataService,
     Discovery,
     GmsRegistryEntry,
@@ -453,7 +456,7 @@ class ResourceRecordFactory:
             ),
         ]
 
-        return TypedService(
+        return TypedDataService(
             created=registry.created,
             updated=self._startup_timestamp,
             status="active",
@@ -552,6 +555,49 @@ class ResourceRecordFactory:
                         )
                     ]
                 ),
+            ],
+        )
+
+    def _create_data_resource(self, entry: BaseRegistryEntry) -> DataResource:
+        """Create a DataResource record for a dataset collection.
+
+        Parameters
+        ----------
+        entry
+            Registry entry.
+
+        Returns
+        -------
+        DataResource
+            A ``vs:DataResource`` record with no capabilities, serving as
+            the resolvable target for per-object IVOIDs.
+        """
+        return DataResource(
+            created=entry.created,
+            updated=self._startup_timestamp,
+            status="active",
+            title=entry.title,
+            identifier=entry.ivoid,
+            curation=self._curation,
+            content=Content(
+                subject=self._registry_config.subjects + entry.subjects,
+                description=entry.description,
+                reference_url=(
+                    entry.docs_url
+                    or self._registry_config.organisation.homepage
+                ),
+                type=[IvoaContentType.ARCHIVE],
+                content_level=[IvoaContentLevel.RESEARCH],
+            ),
+            facility=self._resource_names(
+                entry.facilities or self._registry_config.facilities
+            ),
+            instrument=self._resource_names(entry.instruments),
+            rights=[
+                Rights(
+                    value=self._registry_config.rights,
+                    rights_uri=self._registry_config.rights_uri,
+                )
             ],
         )
 
@@ -721,5 +767,10 @@ class ResourceRecordFactory:
                     self._add_tap_catalog_resource(
                         records, dataset, service, service.ivoa_registry
                     )
+
+        for entry in self._registry_config.dataset_records.values():
+            ivoid = str(entry.ivoid)
+            if ivoid not in records:
+                records[ivoid] = self._create_data_resource(entry)
 
         return RecordStore(records=records)

--- a/src/repertoire/registry/models.py
+++ b/src/repertoire/registry/models.py
@@ -161,6 +161,27 @@ class TypedService(Service, tag="Resource", nsmap=_RESOURCE_NSMAP, ns="ri"):
     ) = element(tag="capability", default_factory=list)
 
 
+class DataResource(Service, tag="Resource", nsmap=_RESOURCE_NSMAP, ns="ri"):
+    """Resource serialized as ``<ri:Resource xsi:type="vs:DataResource">``.
+
+    Used for dataset collection records that serve as the resolvable target
+    for per-object IVOIDs (Butler datasets, HiPS surveys).
+    """
+
+    type: Literal["vs:DataResource"] = attr(
+        ns="xsi", default="vs:DataResource"
+    )
+    facility: list[ResourceName] = element(
+        tag="facility", ns="", default_factory=list
+    )
+    instrument: list[ResourceName] = element(
+        tag="instrument", ns="", default_factory=list
+    )
+    rights: list[Rights] | None = element(
+        tag="rights", ns="", default_factory=list
+    )
+
+
 class CatalogResource(Service, tag="Resource", nsmap=_RESOURCE_NSMAP, ns="ri"):
     """Resource serialized as:
     ``<ri:Resource xsi:type="vs:CatalogResource">``.
@@ -181,6 +202,35 @@ class CatalogResource(Service, tag="Resource", nsmap=_RESOURCE_NSMAP, ns="ri"):
     capability: list[TapAux | Capability] | None = element(
         tag="capability", default_factory=list
     )
+
+
+class TypedDataService(
+    Service, tag="Resource", nsmap=_RESOURCE_NSMAP, ns="ri"
+):
+    """DataService serialized as:
+    ``<ri:Resource xsi:type="vs:DataService">``.
+    """
+
+    type: Literal["vs:DataService"] = attr(ns="xsi", default="vs:DataService")
+    facility: list[ResourceName] = element(
+        tag="facility", ns="", default_factory=list
+    )
+    instrument: list[ResourceName] = element(
+        tag="instrument", ns="", default_factory=list
+    )
+    rights: list[Rights] | None = element(
+        tag="rights", ns="", default_factory=list
+    )
+    capability: (
+        list[
+            SODASync
+            | SODAAsync
+            | VOSICapabilities
+            | VOSIAvailability
+            | Capability
+        ]
+        | None
+    ) = element(tag="capability", default_factory=list)
 
 
 class RegistryOrganisation(

--- a/tests/data/config/registry.yaml
+++ b/tests/data/config/registry.yaml
@@ -57,6 +57,11 @@ datasets:
       Commissioning Camera of seven ~1 square degree fields, over seven weeks
       in late 2024.
     docsUrl: "https://dp1.example.com/"
+    ivoaRegistry:
+      ivoid: "ivo://example.com/dp1/datasets"
+      title: "Example Dataset (DP1)"
+      created: "2026-04-16T00:00:00"
+      description: "DP1 dataset collection."
   other:
     description: >-
       Test dataset not listed in availableDatasets.
@@ -101,12 +106,6 @@ ivoaRegistry:
   ivoid: "ivo://example.com/registry"
   repositoryName: "Example Publishing Registry"
   rights: "Restricted to authorized data rights holders."
-  datasetRecords:
-    dp1:
-      ivoid: "ivo://example.com/dp1/datasets"
-      title: "Example Dataset (DP1)"
-      created: "2026-04-16T00:00:00"
-      description: "DP1 dataset collection."
   organisation:
     created: "2026-04-16T00:00:00Z"
     description: "Example Observatory for testing."

--- a/tests/data/config/registry.yaml
+++ b/tests/data/config/registry.yaml
@@ -101,6 +101,12 @@ ivoaRegistry:
   ivoid: "ivo://example.com/registry"
   repositoryName: "Example Publishing Registry"
   rights: "Restricted to authorized data rights holders."
+  datasetRecords:
+    dp1:
+      ivoid: "ivo://example.com/dp1/datasets"
+      title: "Example Dataset (DP1)"
+      created: "2026-04-16T00:00:00"
+      description: "DP1 dataset collection."
   organisation:
     created: "2026-04-16T00:00:00Z"
     description: "Example Observatory for testing."

--- a/tests/data/output/registry/list_identifiers.xml
+++ b/tests/data/output/registry/list_identifiers.xml
@@ -48,5 +48,10 @@
       <datestamp>1970-01-01T00:00:00Z</datestamp>
       <setSpec>ivo_managed</setSpec>
     </header>
+    <header>
+      <identifier>ivo://example.com/dp1/datasets</identifier>
+      <datestamp>1970-01-01T00:00:00Z</datestamp>
+      <setSpec>ivo_managed</setSpec>
+    </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/tests/data/output/registry/list_records.xml
+++ b/tests/data/output/registry/list_records.xml
@@ -244,7 +244,7 @@
         <setSpec>ivo_managed</setSpec>
       </header>
       <metadata>
-        <ri:Resource xmlns="" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0" created="2026-04-16T00:00:00.000Z" updated="1970-01-01T00:00:00.000Z" status="active" xsi:type="vs:CatalogService">
+        <ri:Resource xmlns="" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0" created="2026-04-16T00:00:00.000Z" updated="1970-01-01T00:00:00.000Z" status="active" xsi:type="vs:DataService">
           <title>Example SODA Cutout Service</title>
           <identifier>ivo://example.com/cutout</identifier>
           <curation>
@@ -369,6 +369,36 @@
             </interface>
           </capability>
           <instrument>ExampleCam</instrument>
+        </ri:Resource>
+      </metadata>
+    </record>
+    <record>
+      <header>
+        <identifier>ivo://example.com/dp1/datasets</identifier>
+        <datestamp>1970-01-01T00:00:00Z</datestamp>
+        <setSpec>ivo_managed</setSpec>
+      </header>
+      <metadata>
+        <ri:Resource xmlns="" xmlns:vr="http://www.ivoa.net/xml/VOResource/v1.0" xmlns:vs="http://www.ivoa.net/xml/VODataService/v1.1" xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0" created="2026-04-16T00:00:00.000Z" updated="1970-01-01T00:00:00.000Z" status="active" xsi:type="vs:DataResource">
+          <title>Example Dataset (DP1)</title>
+          <identifier>ivo://example.com/dp1/datasets</identifier>
+          <curation>
+            <publisher>Example Observatory</publisher>
+            <creator>
+              <name>Example Observatory</name>
+            </creator>
+            <contact>
+              <name>Example Observatory</name>
+              <email>registry@example.com</email>
+            </contact>
+          </curation>
+          <content>
+            <description>DP1 dataset collection.</description>
+            <referenceURL>https://example.com/</referenceURL>
+            <type>Archive</type>
+            <contentLevel>Research</contentLevel>
+          </content>
+          <rights>Restricted to authorized data rights holders.</rights>
         </ri:Resource>
       </metadata>
     </record>

--- a/tests/handlers/registry_test.py
+++ b/tests/handlers/registry_test.py
@@ -370,3 +370,18 @@ async def test_tap_subjects_and_facility(client: AsyncClient) -> None:
     assert r.status_code == 200
     assert "<subject>photometry</subject>" in r.text
     assert "<facility>Example:Telescope</facility>" in r.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("app", ["registry"], indirect=True)
+async def test_soda_resource_record(client: AsyncClient) -> None:
+    r = await client.get(
+        "/api/registry"
+        "?verb=GetRecord"
+        "&metadataPrefix=ivo_vor"
+        "&identifier=ivo://example.com/cutout"
+    )
+    assert r.status_code == 200
+    xml = r.text
+    assert 'xsi:type="vs:DataService"' in xml
+    assert "<type>Archive</type>" in xml


### PR DESCRIPTION
## Changes
- Cutout service needs to be declared a `vs:DataService` instead of a `CatalogService`, so this PR includes new model (`TypedDataService`) and factory changes to support that.
- We also need a top level {release}/datasets `vs:DataResource` which will be the resolvable registry target for butler and hips per-object IVOIDs.