### PR TITLE
DM-55530: Add column index auto-increment flag to Felis schema creation

### DIFF
--- a/changelog.d/20260717_173707_steliosvoutsinas_DM_55530.md
+++ b/changelog.d/20260717_173707_steliosvoutsinas_DM_55530.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Add column index auto-increment flag to Felis schema creation

--- a/src/repertoire/services/tap_schema.py
+++ b/src/repertoire/services/tap_schema.py
@@ -292,6 +292,7 @@ class TAPSchemaService:
                 context={
                     "id_generation": True,
                     "force_unbounded_arraysize": True,
+                    "column_ref_index_increment": 10,
                 },
             )
 


### PR DESCRIPTION
This flag is passed into Felis to tell it to add an auto-incrementing column_index to the inserted fields. Note that this only applies to columns defined as columnRefs.